### PR TITLE
Feat/optimize read

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ospec": "^4.0.0",
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.7.0-beta"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cli/src/action.dump.tile.ts
+++ b/packages/cli/src/action.dump.tile.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { ActionUtil, CliResultMap } from './action.util';
 import { writeTile, getTileName } from './util.tile';
 import { toByteSizeString } from './util.bytes';
+import { CliLogger } from './cli.log';
 
 const Rad2Deg = 180 / Math.PI;
 const A = 6378137.0; // 900913 properties.
@@ -49,7 +50,7 @@ export class ActionDumpTile extends CommandLineAction {
             summary: 'Dump tiles from a COG',
             documentation: 'Stuff',
         });
-        this.logger = Log.get().child({ action: 'tile' });
+        this.logger = CliLogger.child({ action: 'tile' });
     }
 
     // TODO this only works for WSG84

--- a/packages/cli/src/action.dump.tile.ts
+++ b/packages/cli/src/action.dump.tile.ts
@@ -1,12 +1,12 @@
-import { CogLogger, CogTiff, Log, TiffVersion } from '@cogeotiff/core';
+import { CogLogger, CogTiff, TiffVersion } from '@cogeotiff/core';
 import { CommandLineAction, CommandLineIntegerParameter, CommandLineStringParameter } from '@microsoft/ts-command-line';
 import chalk from 'chalk';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { ActionUtil, CliResultMap } from './action.util';
-import { writeTile, getTileName } from './util.tile';
-import { toByteSizeString } from './util.bytes';
 import { CliLogger } from './cli.log';
+import { toByteSizeString } from './util.bytes';
+import { getTileName, writeTile } from './util.tile';
 
 const Rad2Deg = 180 / Math.PI;
 const A = 6378137.0; // 900913 properties.

--- a/packages/cli/src/action.tile.ts
+++ b/packages/cli/src/action.tile.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { ActionUtil, CliResultMap } from './action.util';
 import { writeTile } from './util.tile';
 import { toByteSizeString } from './util.bytes';
+import { CliLogger } from './cli.log';
 
 export class ActionTile extends CommandLineAction {
     private file: CommandLineStringParameter | null = null;
@@ -18,7 +19,7 @@ export class ActionTile extends CommandLineAction {
     }
 
     async onExecute(): Promise<void> {
-        const logger = Log.get().child({ action: 'tile' });
+        const logger = CliLogger.child({ action: 'tile' });
         // abstract
         const { tif } = await ActionUtil.getCogSource(this.file);
         if (this.xyz == null || this.xyz.value == null) {

--- a/packages/cli/src/action.tile.ts
+++ b/packages/cli/src/action.tile.ts
@@ -1,10 +1,10 @@
-import { Log, TiffVersion } from '@cogeotiff/core';
+import { TiffVersion } from '@cogeotiff/core';
 import { CommandLineAction, CommandLineStringParameter } from '@microsoft/ts-command-line';
 import chalk from 'chalk';
 import { ActionUtil, CliResultMap } from './action.util';
-import { writeTile } from './util.tile';
-import { toByteSizeString } from './util.bytes';
 import { CliLogger } from './cli.log';
+import { toByteSizeString } from './util.bytes';
+import { writeTile } from './util.tile';
 
 export class ActionTile extends CommandLineAction {
     private file: CommandLineStringParameter | null = null;

--- a/packages/cli/src/cli.cog.info.ts
+++ b/packages/cli/src/cli.cog.info.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { ActionDumpTile } from './action.dump.tile';
 import { ActionCogInfo } from './action.info';
 import { ActionTile } from './action.tile';
-import { ChalkLogStream } from './cli.log';
+import { ChalkLogStream, CliLogger } from './cli.log';
 
 export class CogInfoCommandLine extends CommandLineParser {
     verbose = this.defineFlagParameter({
@@ -34,12 +34,7 @@ export class CogInfoCommandLine extends CommandLineParser {
         if (!chalk.supportsColor) {
             return super.onExecute();
         }
-        const logger = Log.createLogger({
-            name: 'coginfo',
-            hostname: '',
-            streams: [ChalkLogStream],
-        });
-        Core.Log.set(logger);
+        Core.Log.set(CliLogger);
 
         if (this.verbose.value) {
             ChalkLogStream.level = Log.INFO;

--- a/packages/cli/src/cli.log.ts
+++ b/packages/cli/src/cli.log.ts
@@ -78,3 +78,9 @@ export const ChalkLogStream = {
         console.log(`${output} ${kvString}`);
     },
 };
+
+export const CliLogger = Log.createLogger({
+    name: 'coginfo',
+    hostname: '',
+    streams: [ChalkLogStream],
+});

--- a/packages/core/src/cog.tiff.ts
+++ b/packages/core/src/cog.tiff.ts
@@ -111,10 +111,10 @@ export class CogTiff {
         this.images.push(image);
         const size = image.size;
         if (!image.isTiled()) {
-            getLogger().warn('Tiff is not tiled');
+            getLogger()?.warn('Tiff is not tiled');
         } else {
             const tile = image.tileSize;
-            getLogger().debug(
+            getLogger()?.debug(
                 {
                     ...size,
                     tileWidth: tile.width,
@@ -126,7 +126,7 @@ export class CogTiff {
         }
 
         if (nextOffset) {
-            getLogger().trace({ offset: toHexString(nextOffset) }, 'NextImageOffset');
+            getLogger()?.trace({ offset: toHexString(nextOffset) }, 'NextImageOffset');
             await this.source.loadBytes(nextOffset, 1024);
             await this.processIfd(nextOffset);
         } else {
@@ -138,7 +138,7 @@ export class CogTiff {
         const view = this.source.getView(offset);
         const tagCount = view.offset();
         const byteStart = offset + this.source.config.offset;
-        const logger = getLogger().child({ imageId: this.images.length });
+        const logger = getLogger()?.child({ imageId: this.images.length });
         const tags: Map<TiffTag, CogTiffTagBase> = new Map();
 
         let pos = byteStart;
@@ -147,7 +147,7 @@ export class CogTiff {
             pos += tag.size;
 
             if (tag.name == null) {
-                logger.error({ code: toHexString(tag.id) }, `IFDUnknown`);
+                logger?.error({ code: toHexString(tag.id) }, `IFDUnknown`);
                 continue;
             }
 
@@ -157,10 +157,10 @@ export class CogTiff {
                 tagName: tag.name,
             };
             if (tag.value == null) {
-                logger.trace({ ...logObj, ptr: toHexString(tag.valuePointer) }, 'PartialReadIFD');
+                logger?.trace({ ...logObj, ptr: toHexString(tag.valuePointer) }, 'PartialReadIFD');
             } else {
                 const displayValue = Array.isArray(tag.value) ? `[${tag.value.length}]` : tag.value;
-                logger.trace({ ...logObj, value: displayValue }, 'ReadIFD');
+                logger?.trace({ ...logObj, value: displayValue }, 'ReadIFD');
             }
             tags.set(tag.id, tag);
         }

--- a/packages/core/src/cog.tiff.ts
+++ b/packages/core/src/cog.tiff.ts
@@ -154,8 +154,8 @@ export class CogTiff {
                 continue;
             }
 
-            if (tag.value == null) {
-                if (logger != null) {
+            if (logger != null) {
+                if (!tag.isReady) {
                     logger.trace(
                         {
                             offset: toHexString(pos - offset),
@@ -165,10 +165,8 @@ export class CogTiff {
                         },
                         'PartialReadIFD',
                     );
-                }
-            } else {
-                const displayValue = Array.isArray(tag.value) ? `[${tag.value.length}]` : tag.value;
-                if (logger != null) {
+                } else {
+                    const displayValue = Array.isArray(tag.value) ? `[${tag.value.length}]` : tag.value;
                     logger.trace(
                         {
                             offset: toHexString(pos - offset),

--- a/packages/core/src/read/tag/tiff.tag.base.ts
+++ b/packages/core/src/read/tag/tiff.tag.base.ts
@@ -28,16 +28,18 @@ export abstract class CogTiffTagBase<T = any> {
     /** Number of records inside the tag */
     dataCount: number;
 
-    constructor(source: CogSource, offset: number, view: CogSourceView) {
+    constructor(id: number, source: CogSource, offset: number, view: CogSourceView) {
         this.view = view;
         this.source = source;
         this.byteOffset = offset;
 
-        this.id = this.view.uint16At(0);
+        this.id = id;
         this.name = TiffTag[this.id];
 
         this.dataType = this.view.uint16At(2);
         this.dataCount = this.view.uintAt(4, this.source.config.offset);
+        this.dataTypeSize = getTiffTagSize(this.dataType);
+        this.dataLength = this.dataTypeSize * this.dataCount;
     }
 
     /**
@@ -60,11 +62,8 @@ export abstract class CogTiffTagBase<T = any> {
      * @remarks
      * This is only the size of one instance of the data @see this.dataLength for total byte size
      *
-     * @returns size in bytes of the tag data
      */
-    get dataTypeSize(): number {
-        return getTiffTagSize(this.dataType);
-    }
+    dataTypeSize: number;
 
     /**
      * Get a human readable name for a datatype
@@ -77,9 +76,7 @@ export abstract class CogTiffTagBase<T = any> {
     /**
      * Get the number of bytes used for the all of the data
      */
-    get dataLength(): number {
-        return this.dataTypeSize * this.dataCount;
-    }
+    dataLength: number;
 
     /** absolute offset of the Tag value */
     get valuePointer(): number {

--- a/packages/core/src/read/tag/tiff.tag.lazy.ts
+++ b/packages/core/src/read/tag/tiff.tag.lazy.ts
@@ -5,8 +5,8 @@ import { CogTiffTagBase } from './tiff.tag.base';
 
 export class CogTiffTagLazy<T> extends CogTiffTagBase<T> {
     private fetchable: Fetchable<T>;
-    constructor(source: CogSource, offset: number, view: CogSourceView) {
-        super(source, offset, view);
+    constructor(tagId: number, source: CogSource, offset: number, view: CogSourceView) {
+        super(tagId, source, offset, view);
         this.fetchable = new Fetchable(this.loadValueFromPtr.bind(this));
     }
 

--- a/packages/core/src/read/tag/tiff.tag.offset.ts
+++ b/packages/core/src/read/tag/tiff.tag.offset.ts
@@ -10,8 +10,8 @@ import { CogTiffTagBase } from './tiff.tag.base';
 export class CogTiffTagOffset extends CogTiffTagBase<number[]> {
     private loadedValues: number[] | null = null;
 
-    constructor(source: CogSource, offset: number, view: CogSourceView) {
-        super(source, offset, view);
+    constructor(tagId: number, source: CogSource, offset: number, view: CogSourceView) {
+        super(tagId, source, offset, view);
     }
 
     get value(): number[] | null {

--- a/packages/core/src/read/tag/tiff.tag.static.ts
+++ b/packages/core/src/read/tag/tiff.tag.static.ts
@@ -3,12 +3,19 @@ import { CogSourceView } from '../../source/cog.source.view';
 import { CogTiffTagBase } from './tiff.tag.base';
 
 export class CogTifTagStatic<T> extends CogTiffTagBase<T> {
-    value: T | null = null;
+    _isRead: boolean = false;
+    _value: T | null = null;
 
-    constructor(source: CogSource, offset: number, view: CogSourceView) {
-        super(source, offset, view);
-        if (this.hasBytes) {
-            this.value = this.readValue();
+    constructor(tagId: number, source: CogSource, offset: number, view: CogSourceView) {
+        super(tagId, source, offset, view);
+    }
+
+    /** Lazy read the inline tiff tags */
+    get value() {
+        if (this._isRead == false) {
+            this._value = this.readValue();
+            this._isRead = true;
         }
+        return this._value;
     }
 }

--- a/packages/core/src/read/tiff.tag.ts
+++ b/packages/core/src/read/tiff.tag.ts
@@ -18,15 +18,15 @@ export const CogTiffTag = {
         const view = source.getView(offset);
         const tagId = view.uint16At(0);
         if (tagId === TiffTag.TileOffsets || tagId === TiffTag.TileByteCounts) {
-            return new CogTiffTagOffset(source, offset, view);
+            return new CogTiffTagOffset(tagId, source, offset, view);
         }
 
-        const staticTag = new CogTifTagStatic(source, offset, view);
+        const staticTag = new CogTifTagStatic(tagId, source, offset, view);
         if (staticTag.hasBytes) {
             return staticTag;
         }
 
-        return new CogTiffTagLazy(source, offset, view);
+        return new CogTiffTagLazy(tagId, source, offset, view);
     },
 
     isStatic<T>(tiffTag: CogTiffTagBase<T>): tiffTag is CogTifTagStatic<T> {

--- a/packages/core/src/source/cog.source.chunked.ts
+++ b/packages/core/src/source/cog.source.chunked.ts
@@ -36,7 +36,7 @@ export abstract class CogSourceChunked extends CogSource {
      *
      * @returns loaded chunk data as one buffer
      */
-    protected abstract loadChunks(firstChunk: number, lastChunk: number, log: CogLogger): Promise<ArrayBuffer>;
+    protected abstract loadChunks(firstChunk: number, lastChunk: number, log: CogLogger | null): Promise<ArrayBuffer>;
 
     /**
      * Split the ranges into a consecutive chunks

--- a/packages/core/src/source/cog.source.ts
+++ b/packages/core/src/source/cog.source.ts
@@ -43,6 +43,21 @@ export abstract class CogSource {
     }
 
     /**
+     * Determine if the number of bytes are included in a single chunk
+     *
+     * @returns chunkId if the data is contained inside one chunk otherwise null.
+     */
+    private isOneChunk(offset: number, byteCount: ByteSize): number | null {
+        const chunkSize = this.chunkSize;
+        const startChunk = offset / chunkSize;
+        const endChunk = (offset + byteCount) / chunkSize;
+        if (endChunk - startChunk < 1) {
+            return Math.floor(startChunk);
+        }
+        return null;
+    }
+
+    /**
      * Read a Uint8 at the offset
      * @param offset Offset relative to the view
      */
@@ -53,6 +68,12 @@ export abstract class CogSource {
 
     /** Read a UInt16 at the offset */
     uint16(offset: number): number {
+        const chunkId = this.isOneChunk(offset, ByteSize.UInt8);
+        if (chunkId != null) {
+            const chunk = this.chunk(chunkId);
+            return chunk.view.getUint16(offset - chunk.offset, this.isLittleEndian);
+        }
+
         const intA = this.uint8(offset);
         const intB = this.uint8(offset + ByteSize.UInt8);
         if (this.isLittleEndian) {
@@ -63,6 +84,13 @@ export abstract class CogSource {
 
     /** Read a UInt32 at the offset */
     uint32(offset: number): number {
+        // If all the data is contained inside one Chunk, Load the bytes directly
+        const chunkId = this.isOneChunk(offset, ByteSize.UInt32);
+        if (chunkId != null) {
+            const chunk = this.chunk(chunkId);
+            return chunk.view.getUint32(offset - chunk.offset, this.isLittleEndian);
+        }
+
         const intA = this.uint8(offset);
         const intB = this.uint8(offset + 1);
         const intC = this.uint8(offset + 2);
@@ -81,6 +109,13 @@ export abstract class CogSource {
      * @param offset offset to read
      */
     uint64(offset: number): number {
+        // If all the data is contained inside one Chunk, Load the bytes directly
+        const chunkId = this.isOneChunk(offset, ByteSize.UInt64);
+        if (chunkId != null) {
+            const chunk = this.chunk(chunkId);
+            return Number(chunk.view.getBigUint64(offset - chunk.offset, this.isLittleEndian));
+        }
+
         const intA = this.uint32(offset);
         const intB = this.uint32(offset + ByteSize.UInt32);
         if (this.isLittleEndian) {

--- a/packages/core/src/source/cog.source.ts
+++ b/packages/core/src/source/cog.source.ts
@@ -233,8 +233,10 @@ export abstract class CogSource {
 
     /** Check if the number of bytes has been cached so far */
     hasBytes(offset: number, count = 1) {
-        const requiredChunks = this.getRequiredChunks(offset, count);
-        for (const chunk of requiredChunks) {
+        const startChunk = Math.floor(offset / this.chunkSize);
+        const endChunk = Math.ceil((offset + count) / this.chunkSize) - 1;
+        for (let chunkId = startChunk; chunkId <= endChunk; chunkId++) {
+            const chunk = this.chunk(chunkId);
             if (!chunk.isReady()) {
                 return false;
             }

--- a/packages/core/src/util/util.log.ts
+++ b/packages/core/src/util/util.log.ts
@@ -16,7 +16,10 @@ export const LoggerConfig: { log: CogLogger | null } = { log: null };
 /**
  * Get the current logger
  */
-export function getLogger() {
+export function getLogger(keys?: Record<string, any>) {
+    if (keys && LoggerConfig.log != null) {
+        return LoggerConfig.log.child(keys);
+    }
     return LoggerConfig.log;
 }
 /** Set a logger to be used */

--- a/packages/core/src/util/util.log.ts
+++ b/packages/core/src/util/util.log.ts
@@ -1,5 +1,3 @@
-const noop = (data: Record<string, any>, msg?: string) => undefined;
-
 /** Interface required for a logger, should match common loggers, bunyan, pino, bblog */
 export interface CogLogger {
     trace(data: Record<string, any> | string, msg?: string): void;

--- a/packages/core/src/util/util.log.ts
+++ b/packages/core/src/util/util.log.ts
@@ -11,16 +11,7 @@ export interface CogLogger {
     child(keys: Record<string, any>): CogLogger;
 }
 
-const FakeLogger: CogLogger = {
-    trace: noop,
-    debug: noop,
-    info: noop,
-    warn: noop,
-    error: noop,
-    fatal: noop,
-    child: (keys: Record<string, any>) => FakeLogger,
-};
-export const LoggerConfig: { log: CogLogger } = { log: FakeLogger };
+export const LoggerConfig: { log: CogLogger | null } = { log: null };
 
 /**
  * Get the current logger

--- a/packages/source-aws/src/cog.source.aws.s3.ts
+++ b/packages/source-aws/src/cog.source.aws.s3.ts
@@ -39,20 +39,22 @@ export class CogSourceAwsS3 extends CogSourceChunked {
         return new CogTiff(new CogSourceAwsS3(bucket, key)).init();
     }
 
-    protected async loadChunks(firstChunk: number, lastChunk: number, log: CogLogger): Promise<ArrayBuffer> {
+    protected async loadChunks(firstChunk: number, lastChunk: number, logger: CogLogger | null): Promise<ArrayBuffer> {
         const fetchRange = `bytes=${firstChunk * this.chunkSize}-${lastChunk * this.chunkSize + this.chunkSize}`;
         const chunkCount = lastChunk - firstChunk || 1;
 
-        log.info(
-            {
-                firstChunk,
-                lastChunk,
-                chunkCount,
-                bytes: chunkCount * this.chunkSize,
-                fetchRange,
-            },
-            'S3Get',
-        );
+        if (logger != null) {
+            logger.info(
+                {
+                    firstChunk,
+                    lastChunk,
+                    chunkCount,
+                    bytes: chunkCount * this.chunkSize,
+                    fetchRange,
+                },
+                'S3Get',
+            );
+        }
 
         const response = await this.s3
             .getObject({

--- a/packages/source-url/src/cog.source.url.ts
+++ b/packages/source-url/src/cog.source.url.ts
@@ -33,27 +33,31 @@ export class CogSourceUrl extends CogSourceChunked {
         return new CogTiff(new CogSourceUrl(url)).init();
     }
 
-    protected async loadChunks(firstChunk: number, lastChunk: number, logger: CogLogger): Promise<ArrayBuffer> {
+    protected async loadChunks(firstChunk: number, lastChunk: number, logger: CogLogger | null): Promise<ArrayBuffer> {
         const Range = `bytes=${firstChunk * this.chunkSize}-${lastChunk * this.chunkSize + this.chunkSize}`;
         const chunkCount = lastChunk - firstChunk || 1;
 
-        logger.info(
-            { firstChunk, lastChunk, chunkCount, bytes: chunkCount * this.chunkSize, fetchRange: Range },
-            'HTTPGet',
-        );
+        if (logger != null) {
+            logger.info(
+                { firstChunk, lastChunk, chunkCount, bytes: chunkCount * this.chunkSize, fetchRange: Range },
+                'HTTPGet',
+            );
+        }
 
         const headers = { Range };
         const response = await CogSourceUrl.fetch(this.url, { headers });
 
         if (!response.ok) {
-            logger.error(
-                {
-                    status: response.status,
-                    statusText: response.statusText,
-                    url: this.url,
-                },
-                'Failed to fetch',
-            );
+            if (logger != null) {
+                logger.error(
+                    {
+                        status: response.status,
+                        statusText: response.statusText,
+                        url: this.url,
+                    },
+                    'Failed to fetch',
+                );
+            }
             throw new Error('Failed to fetch');
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5392,10 +5392,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.1:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^3.7.0-beta:
+  version "3.7.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-beta.tgz#4ad556e0eee14b90ecc39261001690e16e5eeba9"
+  integrity sha512-4jyCX+IQamrPJxgkABPq9xf+hUN+GWHVxoj+oey1TadCPa4snQl1RKwUba+1dyzYCamwlCxKvZQ3TjyWLhMGBA==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
Optimize the initialization process to load only the data that is needed.

- LazyLoad IFD tags as neeeded
- Combine `uint64/32` reads into one read if they are in the same chunk
- Remove `toHexString` and Logging calls if no logger is provided.

This reduced load time of loading 10,000 large geotiff from 2500ms to 700ms 