### PR TITLE
fix: allow CogTiff.init() to be called multiple times

### DIFF
--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -57,4 +57,18 @@ o.spec('CogRead', () => {
         const [firstTif] = tif.images;
         o(firstTif.compression).equals(TiffMimeType.JPEG);
     });
+
+    o('should allow multiple init', async () => {
+        const source = new TestFileCogSource(path.join(__dirname, '../..' + '/data/cog.tif'));
+        const tif = new CogTiff(source);
+
+        o(tif.isInitialized).equals(false);
+        await tif.init();
+        o(tif.isInitialized).equals(true);
+        o(tif.images.length).equals(5);
+
+        o(tif.isInitialized).equals(true);
+        await tif.init();
+        o(tif.images.length).equals(5);
+    });
 });

--- a/packages/core/src/cog.tiff.ts
+++ b/packages/core/src/cog.tiff.ts
@@ -21,17 +21,22 @@ export class CogTiff {
         this.source = source;
     }
 
+    /** Has init() been called */
+    isInitialized = false;
+
     /**
      * Initialize the COG loading in the header and all image headers
      *
      * @param loadGeoKeys Whether to also initialize the GeoKeyDirectory
      */
     async init(loadGeoKeys = false): Promise<CogTiff> {
+        if (this.isInitialized) return this;
         // Load the first few KB in, more loads will run as more data is required
         await this.source.loadBytes(0, 4 * HEADER_BUFFER_SIZE);
         await this.fetchIfd();
-        await Promise.all(this.images.map(c => c.init(loadGeoKeys)));
+        await Promise.all(this.images.map((c) => c.init(loadGeoKeys)));
 
+        this.isInitialized = true;
         return this;
     }
 


### PR DESCRIPTION
Previously this would continually add more images to the images array, now this exits early if it has already been initalized