### PR TITLE
fix(core): do no read too many bytes from the file

### DIFF
--- a/packages/core/src/cog.tiff.image.ts
+++ b/packages/core/src/cog.tiff.image.ts
@@ -400,7 +400,7 @@ export class CogTiffImage {
             const leaderBytes = this.tif.options.tileLeaderByteSize;
             // This fetch will generally load in the bytes needed for the image too
             // provided the image size is less than the size of a chunk
-            await this.tif.source.loadBytes(offset - leaderBytes, this.tif.source.chunkSize);
+            await this.tif.source.loadBytes(offset - leaderBytes, leaderBytes);
             return { offset, imageSize: this.tif.source.uint(offset - leaderBytes, leaderBytes) };
         }
 


### PR DESCRIPTION
This can cause issues with S3, if requesting bytes outside the range of the file it will return "InvalidRange: The requested range is not satisfiable"