### PR TITLE
feat!: better support for sparse tiffs

### DIFF
--- a/packages/cli/src/action.dump.tile.ts
+++ b/packages/cli/src/action.dump.tile.ts
@@ -110,18 +110,21 @@ export class ActionDumpTile extends CommandLineAction {
             return;
         }
 
-        const tileCount = img.tileCount;
+        const { tileCount, tileSize } = img;
 
-        const html = ['<html>'];
+        const styles = `<style>.c { min-width: ${tileSize.width}px; min-height: ${tileSize.height}px }</style>`;
+
+        const html = ['<html>', styles];
         for (let y = 0; y < tileCount.y; y++) {
             html.push('\t<div style="display:flex;">');
             for (let x = 0; x < tileCount.x; x++) {
-                const tile = await tif.getTileRaw(x, y, index);
+                const tile = await tif.getTile(x, y, index);
                 if (tile == null) {
+                    html.push(`\t\t<div class="c"></div>`);
                     continue;
                 }
 
-                html.push(`\t\t<img src="./${getTileName(tile.mimeType, index, x, y)}" >`);
+                html.push(`\t\t<img class="c" src="./${getTileName(tile.mimeType, index, x, y)}" >`);
             }
 
             html.push('\t</div>');

--- a/packages/cli/src/util.tile.ts
+++ b/packages/cli/src/util.tile.ts
@@ -40,12 +40,12 @@ export async function writeTile(
     outputPath: string,
     logger: CogLogger,
 ) {
-    const tile = await tif.getTileRaw(x, y, index);
+    const tile = await tif.getTile(x, y, index);
     if (tile == null) {
-        logger.error('Unable to write file, missing data..');
+        logger.debug({ index, x, y }, 'TileEmpty');
         return;
     }
     const fileName = getTileName(tile.mimeType, index, x, y);
     await fs.writeFile(path.join(outputPath, fileName), tile.bytes);
-    logger.debug({ fileName }, 'WriteFile');
+    logger.debug({ index, x, y, fileName, bytes: tile.bytes.length }, 'TileWrite');
 }

--- a/packages/core/src/cog.tiff.ts
+++ b/packages/core/src/cog.tiff.ts
@@ -112,7 +112,16 @@ export class CogTiff {
         return firstImage;
     }
 
-    async getTileRaw(x: number, y: number, index: number): Promise<{ mimeType: string; bytes: ArrayBuffer } | null> {
+    /**
+     * Get the raw bytes for a tile at a given x,y, index.
+     *
+     * This may return null if the tile does not exist eg Sparse cogs,
+     *
+     * @param x tile x index
+     * @param y tile y index
+     * @param index image index
+     */
+    async getTile(x: number, y: number, index: number): Promise<{ mimeType: string; bytes: Uint8Array } | null> {
         const image = this.getImage(index);
         if (image == null) {
             throw new Error(`Missing z: ${index}`);


### PR DESCRIPTION
BREAKING CHANGE: getTile now may return null if there is no data for a tile