### PR TITLE
feat: adding uri for a full reference for any source

### DIFF
--- a/packages/core/src/__test__/fake.source.ts
+++ b/packages/core/src/__test__/fake.source.ts
@@ -3,6 +3,7 @@ import { CogSource } from '../source/cog.source';
 
 export class FakeCogSource extends CogSource {
     type = 'fake';
+    uri = 'fake';
     chunkSize = 100;
 
     fetchBytes(offset: number, length: number): Promise<ArrayBuffer> {
@@ -20,6 +21,7 @@ let Id = 0;
 export class TestFileCogSource extends CogSource {
     id = Id++;
     type = 'test-file';
+    uri = '/test/file';
     chunkSize: number = 1024 * 1024 * 1024;
     name: string;
     fileName: string;

--- a/packages/core/src/source/cog.source.ts
+++ b/packages/core/src/source/cog.source.ts
@@ -15,6 +15,9 @@ export abstract class CogSource {
     /** Split the Tif into chunks to be read  */
     abstract chunkSize: number;
 
+    /** Reference to the source */
+    abstract uri: string;
+
     // TODO this should ideally be a LRU
     // With a priority for the first few chunks (Generally where the main IFD resides)
     chunks: CogChunk[] = [];

--- a/packages/source-aws/src/cog.source.aws.s3.ts
+++ b/packages/source-aws/src/cog.source.aws.s3.ts
@@ -29,6 +29,10 @@ export class CogSourceAwsS3 extends CogSourceChunked {
         this.s3 = s3;
     }
 
+    get uri() {
+        return this.name;
+    }
+
     get name() {
         return `s3://${this.bucket}/${this.key}`;
     }

--- a/packages/source-file/src/__test__/cog.source.file.test.ts
+++ b/packages/source-file/src/__test__/cog.source.file.test.ts
@@ -35,7 +35,10 @@ o.spec('CogSourceFile', () => {
         o(bytesB.byteLength).equals(1);
         o(source.fd).equals(null);
     });
-
+    o('should resolve uri', () => {
+        o(source.uri[0]).equals('/');
+        o(source.name).equals('rgba8_tiled.tiff');
+    });
     o('should read very small tiffs', async () => {
         source.chunkSize = 1024; // Javascript uses shared memory for small buffers
 

--- a/packages/source-file/src/cog.source.file.ts
+++ b/packages/source-file/src/cog.source.file.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { basename } from 'path';
+import { basename, resolve } from 'path';
 import { CogSource, CogTiff } from '@cogeotiff/core';
 
 const SourceType = 'file';
@@ -42,6 +42,12 @@ export class CogSourceFile extends CogSource {
         this.fd = null;
     }
 
+    /** Full reference path to the file */
+    get uri() {
+        return resolve(this.fileName);
+    }
+
+    /** name of the file */
     get name() {
         return basename(this.fileName);
     }

--- a/packages/source-url/src/cog.source.url.ts
+++ b/packages/source-url/src/cog.source.url.ts
@@ -16,6 +16,10 @@ export class CogSourceUrl extends CogSourceChunked {
         this.url = url;
     }
 
+    get uri() {
+        return this.url;
+    }
+
     get name() {
         return this.url;
     }


### PR DESCRIPTION
- files should resolve "./foo" => /foo/bar/baz
- urls should include "https://foo.bar.com/baz"
- s3 includes "s3://foo-bar/baz"

This does will not expand "~/"