### PR TITLE
feat(source-aws): remove aws-sdk typings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
         "@cogeotiff/source-url": "^2.2.0",
         "@rushstack/ts-command-line": "^4.3.14",
         "ansi-colors": "^4.1.1",
+        "aws-sdk": "^2.781.0",
         "bblog": "^2.0.0",
         "p-limit": "^3.0.1",
         "pretty-json-log": "^0.3.1",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,10 @@
+import { CogSourceAwsS3 } from '@cogeotiff/source-aws';
 import 'source-map-support/register';
 import { CogInfoCommandLine } from './cli.cog.info';
 import { CliLogger } from './cli.log';
+import * as S3 from 'aws-sdk/clients/s3';
+
+CogSourceAwsS3.DefaultS3 = new S3();
 
 const cogInfo: CogInfoCommandLine = new CogInfoCommandLine();
 cogInfo.executeWithoutErrorHandling().catch((error) => {

--- a/packages/source-aws/package.json
+++ b/packages/source-aws/package.json
@@ -8,8 +8,7 @@
     "license": "MIT",
     "scripts": {},
     "dependencies": {
-        "@cogeotiff/core": "^2.2.0",
-        "aws-sdk": "^2.524.0"
+        "@cogeotiff/core": "^2.2.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/source-aws/src/__test__/source.aws.s3.test.ts
+++ b/packages/source-aws/src/__test__/source.aws.s3.test.ts
@@ -1,7 +1,25 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as o from 'ospec';
 import 'source-map-support/register';
-import { CogSourceAwsS3 } from '../cog.source.aws.s3';
+import { CogSourceAwsS3, S3Like, S3LikeResponse } from '../cog.source.aws.s3';
+import { join } from 'path';
+import * as fs from 'fs';
+
+const TestDataPath = join(__dirname, '..', '..', '..', 'core', 'data');
+
+export class FakeRemote implements S3Like {
+    static id = 0;
+    id = FakeRemote.id++;
+    requests: { Bucket: string; Key: string; Range: string }[] = [];
+    data: Buffer;
+    constructor(data: Buffer) {
+        this.data = data;
+    }
+    getObject(ctx: { Bucket: string; Key: string; Range: string }): S3LikeResponse {
+        this.requests.push(ctx);
+        return { promise: () => Promise.resolve({ Body: this.data.slice() }) };
+    }
+}
 
 o.spec('CogSourceAwsS3', () => {
     o('should round trip uri', () => {
@@ -16,5 +34,38 @@ o.spec('CogSourceAwsS3', () => {
 
         // Not s3
         o(CogSourceAwsS3.createFromUri('http://example.com/foo.tiff')).equals(null);
+    });
+
+    const TestFile = join(TestDataPath, 'rgba8_tiled.tiff');
+    o('should create with defaults', async () => {
+        const fileData = await fs.promises.readFile(TestFile);
+        const remote = new FakeRemote(fileData);
+        CogSourceAwsS3.DefaultS3 = remote;
+
+        await CogSourceAwsS3.create('s3://foo/bar');
+        o(remote.requests[0]).deepEquals({ Bucket: 'foo', Key: 'bar', Range: 'bytes=0-65536' });
+
+        await CogSourceAwsS3.create('foo', 'bar');
+        o(remote.requests[1]).deepEquals({ Bucket: 'foo', Key: 'bar', Range: 'bytes=0-65536' });
+    });
+
+    o('should create with passed in remote', async () => {
+        const fileData = await fs.promises.readFile(TestFile);
+
+        const remoteDefault = new FakeRemote(fileData);
+        CogSourceAwsS3.DefaultS3 = remoteDefault;
+
+        const freshRemote = new FakeRemote(fileData);
+        await CogSourceAwsS3.create('s3://foo/bar', freshRemote);
+        o(freshRemote.requests[0]).deepEquals({ Bucket: 'foo', Key: 'bar', Range: 'bytes=0-65536' });
+
+        const freshRemoteB = new FakeRemote(fileData);
+
+        await CogSourceAwsS3.create('foo', 'bar', freshRemoteB);
+        o(freshRemoteB.requests[0]).deepEquals({ Bucket: 'foo', Key: 'bar', Range: 'bytes=0-65536' });
+
+        o(remoteDefault.requests.length).equals(0);
+        o(freshRemoteB.requests.length).equals(1);
+        o(freshRemote.requests.length).equals(1);
     });
 });

--- a/packages/source-aws/src/cog.source.aws.s3.ts
+++ b/packages/source-aws/src/cog.source.aws.s3.ts
@@ -1,5 +1,4 @@
 import { CogLogger, CogSource, CogSourceChunked, CogTiff } from '@cogeotiff/core';
-import * as S3 from 'aws-sdk/clients/s3';
 
 class CompositeError extends Error {
     reason: Error;
@@ -9,8 +8,17 @@ class CompositeError extends Error {
     }
 }
 
+export interface S3LikeResponse {
+    promise(): Promise<{ Body?: Buffer | unknown }>;
+}
+export interface S3Like {
+    getObject(req: { Bucket: string; Key: string; Range: string }): S3LikeResponse;
+}
+
 export class CogSourceAwsS3 extends CogSourceChunked {
     type = 'aws-s3';
+
+    static DefaultS3: S3Like;
 
     // HTTP gets are slow, get a larger amount
     chunkSize: number = 64 * 1024;
@@ -20,20 +28,20 @@ export class CogSourceAwsS3 extends CogSourceChunked {
 
     bucket: string;
     key: string;
-    s3: S3;
+    remote: S3Like;
 
-    constructor(bucket: string, key: string, s3: S3 = new S3()) {
+    constructor(bucket: string, key: string, remote: S3Like) {
         super();
         this.bucket = bucket;
         this.key = key;
-        this.s3 = s3;
+        this.remote = remote;
     }
 
-    get uri() {
+    get uri(): string {
         return this.name;
     }
 
-    get name() {
+    get name(): string {
         return `s3://${this.bucket}/${this.key}`;
     }
 
@@ -72,35 +80,35 @@ export class CogSourceAwsS3 extends CogSourceChunked {
      *
      * @param uri URI to parse
      */
-    static createFromUri(uri: string): CogSourceAwsS3 | null {
+    static createFromUri(uri: string, remote?: S3Like): CogSourceAwsS3 | null {
         const res = CogSourceAwsS3.parse(uri);
-        if (res == null) {
-            return null;
-        }
-        return new CogSourceAwsS3(res.bucket, res.key);
+        if (res == null) return null;
+        return new CogSourceAwsS3(res.bucket, res.key, remote ?? CogSourceAwsS3.DefaultS3);
     }
 
     /**
      * Load a COG from a AWS S3 Bucket
      * @param uri URI to load `s3://foo/baz.tiff`
+     * @param remote Optional S3 Object to use for the requests
      */
-    static async create(uri: string): Promise<CogTiff>;
+    static async create(uri: string, remote?: S3Like): Promise<CogTiff>;
     /**
      * Load a COG from a AWS S3 Bucket
      *
      * @param bucket AWS S3 Bucket name
      * @param key Path to COG inside of bucket
+     * @param remote Optional S3 Object to use for the requests
      */
-    static async create(bucket: string, key: string): Promise<CogTiff>;
-    static async create(sA: string, key?: string): Promise<CogTiff> {
-        if (key == null) {
-            const source = CogSourceAwsS3.createFromUri(sA);
+    static async create(bucket: string, key: string, remote?: S3Like): Promise<CogTiff>;
+    static async create(sA: string, key?: string | S3Like, remote?: S3Like): Promise<CogTiff> {
+        if (typeof key != 'string') {
+            const source = CogSourceAwsS3.createFromUri(sA, key);
             if (source == null) {
                 throw new Error(`Invalid URI ${sA}`);
             }
             return new CogTiff(source).init();
         }
-        return new CogTiff(new CogSourceAwsS3(sA, key)).init();
+        return new CogTiff(new CogSourceAwsS3(sA, key, remote ?? CogSourceAwsS3.DefaultS3)).init();
     }
 
     protected async loadChunks(firstChunk: number, lastChunk: number, logger: CogLogger | null): Promise<ArrayBuffer> {
@@ -117,16 +125,13 @@ export class CogSourceAwsS3 extends CogSourceChunked {
             },
             'S3Get',
         );
-
         try {
-            const res = await this.s3
-                .getObject({
-                    Bucket: this.bucket,
-                    Key: this.key,
-                    Range: fetchRange,
-                })
+            const resp = await this.remote
+                .getObject({ Bucket: this.bucket, Key: this.key, Range: fetchRange })
                 .promise();
-            return (res.Body as Buffer).buffer;
+            if (!Buffer.isBuffer(resp.Body)) throw new Error('Failed to fetch object, Body is not a buffer');
+            const buffer = resp.Body;
+            return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
         } catch (error) {
             logger?.error({ error, source: this.name, firstChunk, lastChunk, fetchRange }, 'FailedToFetch');
             throw new CompositeError(`Failed to fetch ${this.name} ${fetchRange}`, error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,12 +2234,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -3585,12 +3580,7 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
-merge2@^1.2.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
-  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
-
-merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,10 +1253,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.524.0:
-  version "2.712.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.712.0.tgz#828d6ef7556f4b5098c880469ff72195a83f9d66"
-  integrity sha512-C3SLWanFydoWJwtKNi73BG9uB6UzrUuECaAiplOEVBltO/R4sBsHWhwTBuxS02eTNdRrgulu19bJ5RWt+OuXiA==
+aws-sdk@^2.781.0:
+  version "2.781.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.781.0.tgz#e9df63e9b69c22ac939ab675c8771592ae89105a"
+  integrity sha512-y+Xd+DJJyNgZdPLZytJA8LRR79spD/zXOt0G9Uk68UC9tRDEB8aQysuxWKYEybYCexRqJtTZLCrR3ikYwU099g==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
AWS SDK update's its typings quite regularly and will often cause conflicts for people using a different version of aws-sdk in their project.

As the fetcher needs a very simple API `bucket, key, range => Buffer` Using a s3Like interface removes the reliance on the aws-sdk

BREAKING CHANGE: a default s3 object needs to be used when using the S3 Source, this can be set with `
CogSourceAwsS3.DefaultS3 = new S3();`