### PR TITLE
feat!: rename all type from CogTiff to just Tiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Load a COG from a URL using `fetch`
 import { SourceHttp } from '@chunkd/source-http';
 
 const source = new SourceHttp('https://example.com/cog.tif');
-const cog = await CogTiff.create(source);
+const cog = await Tiff.create(source);
 
 const img = cog.images[0];
 if (img.isTiled()) throw new Error('Tiff is not tiled');

--- a/packages/cli/src/commands/dump.ts
+++ b/packages/cli/src/commands/dump.ts
@@ -3,7 +3,7 @@ import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { fsa } from '@chunkd/fs';
-import { CogTiff, TiffMimeType } from '@cogeotiff/core';
+import { Tiff, TiffMimeType } from '@cogeotiff/core';
 import { log } from '@linzjs/tracing';
 import { command, number, option, optional, restPositionals } from 'cmd-ts';
 import pLimit from 'p-limit';
@@ -59,7 +59,7 @@ export const commandDump = command({
       if (path == null) continue;
       if (path.protocol === 's3:') await ensureS3fs();
       const source = fsa.source(path);
-      const tiff = await new CogTiff(source).init();
+      const tiff = await new Tiff(source).init();
       const img = tiff.images[args.image];
       if (!img.isTiled()) throw Error(`Tiff: ${path.href} file is not tiled.`);
       const output = new URL(`${basename(path.href)}-i${args.image}/`, args.output ?? cwd);
@@ -71,7 +71,7 @@ export const commandDump = command({
   },
 });
 
-async function dumpBounds(tiff: CogTiff, target: URL, index: number): Promise<void> {
+async function dumpBounds(tiff: Tiff, target: URL, index: number): Promise<void> {
   const img = tiff.images[index];
   if (!img.isTiled() || !img.isGeoLocated) return;
 
@@ -115,7 +115,7 @@ async function dumpBounds(tiff: CogTiff, target: URL, index: number): Promise<vo
   await fs.writeFile(new URL(`i${index}.bounds.geojson`, target), JSON.stringify(featureCollection, null, 2));
 }
 
-async function dumpTiles(tiff: CogTiff, target: URL, index: number, logger: typeof log): Promise<number> {
+async function dumpTiles(tiff: Tiff, target: URL, index: number, logger: typeof log): Promise<number> {
   const promises: Promise<string | null>[] = [];
   const img = tiff.images[index];
   if (!img.isTiled()) return 0;

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,9 +1,9 @@
 import { fsa } from '@chunkd/fs';
 import {
-  Tiff,
-  TiffImage,
   Tag,
   TagOffset,
+  Tiff,
+  TiffImage,
   TiffTag,
   TiffTagGeo,
   TiffTagGeoValueLookup,

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -45,7 +45,7 @@ export const commandInfo = command({
       FetchLog.reset();
 
       const source = fsa.source(path);
-      const tiff = await new CogTiff(source).init();
+      const tiff = await new Tiff(source).init();
 
       const header = [
         { key: 'Tiff type', value: `${TiffVersion[tiff.version]} (v${String(tiff.version)})` },
@@ -123,7 +123,7 @@ export const commandInfo = command({
   },
 });
 
-const TiffImageInfoTable = new CliTable<CogTiffImage>();
+const TiffImageInfoTable = new CliTable<TiffImage>();
 TiffImageInfoTable.add({ name: 'Id', width: 4, get: (_i, index) => String(index) });
 TiffImageInfoTable.add({ name: 'Size', width: 20, get: (i) => `${i.size.width}x${i.size.height}` });
 TiffImageInfoTable.add({
@@ -169,7 +169,7 @@ TiffImageInfoTable.add({
  * TODO using a XML Parser will make this even better
  * @param img
  */
-function parseGdalMetadata(img: CogTiffImage): string[] | null {
+function parseGdalMetadata(img: TiffImage): string[] | null {
   const metadata = img.value(TiffTag.GdalMetadata);
   if (typeof metadata !== 'string') return null;
   if (!metadata.startsWith('<GDALMetadata>')) return null;

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -1,6 +1,7 @@
 import { fsa } from '@chunkd/fs';
 import {
-  CogTiff,
+  Tiff,
+  TiffImage,
   Tag,
   TagOffset,
   TiffTag,
@@ -10,7 +11,6 @@ import {
   TiffTagValueType,
   TiffVersion,
 } from '@cogeotiff/core';
-import { CogTiffImage } from '@cogeotiff/core/src/cog.tiff.image.js';
 import c from 'ansi-colors';
 import { command, flag, option, optional, restPositionals } from 'cmd-ts';
 

--- a/packages/cli/src/util.tile.ts
+++ b/packages/cli/src/util.tile.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 
-import { CogTiff, TiffMimeType } from '@cogeotiff/core';
+import { Tiff, TiffMimeType } from '@cogeotiff/core';
 import { log } from '@linzjs/tracing';
 
 const FileExtension: Record<string, string> = {
@@ -34,7 +34,7 @@ export function getTileName(mimeType: string, index: number, x: number, y: numbe
 }
 
 export async function writeTile(
-  tiff: CogTiff,
+  tiff: Tiff,
   x: number,
   y: number,
   index: number,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,10 +15,10 @@ Load a COG from a remote http source
 
 ```typescript
 import { SourceHttp } from '@chunkd/source-url';
-import { CogTiff } from '@cogeotiff/core'
+import { Tiff } from '@cogeotiff/core'
 
 const source = new SourceHttp('https://example.com/cog.tif');
-const tiff = await CogTiff.create(source);
+const tiff = await Tiff.create(source);
 
 /** Load a specific tile from a specific image */
 const tile = await tiff.images[5].getTile(2, 2);

--- a/packages/core/src/__benchmark__/cog.read.benchmark.ts
+++ b/packages/core/src/__benchmark__/cog.read.benchmark.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises';
 
-import { Tiff } from '../tiff.js';
 import { TiffTag } from '../index.js';
+import { Tiff } from '../tiff.js';
 import { SourceMemory } from './source.memory.js';
 
 // console.log = console.trace;

--- a/packages/core/src/__benchmark__/cog.read.benchmark.ts
+++ b/packages/core/src/__benchmark__/cog.read.benchmark.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 
-import { CogTiff } from '../tiff.js';
+import { Tiff } from '../tiff.js';
 import { TiffTag } from '../index.js';
 import { SourceMemory } from './source.memory.js';
 
@@ -11,7 +11,7 @@ async function main(): Promise<void> {
   const source = new SourceMemory(buf);
   for (let i = 0; i < 5_000; i++) {
     performance.mark('cog:init');
-    const tiff = new CogTiff(source);
+    const tiff = new Tiff(source);
     await tiff.init();
     performance.mark('cog:init:done');
 

--- a/packages/core/src/__benchmark__/cog.read.benchmark.ts
+++ b/packages/core/src/__benchmark__/cog.read.benchmark.ts
@@ -10,10 +10,10 @@ async function main(): Promise<void> {
   const buf = await readFile(process.argv[process.argv.length - 1]);
   const source = new SourceMemory(buf);
   for (let i = 0; i < 5_000; i++) {
-    performance.mark('cog:init');
+    performance.mark('tiff:init');
     const tiff = new Tiff(source);
     await tiff.init();
-    performance.mark('cog:init:done');
+    performance.mark('tiff:init:done');
 
     // 6 images
     for (const img of tiff.images) await img.getTile(0, 0);

--- a/packages/core/src/__benchmark__/cog.read.benchmark.ts
+++ b/packages/core/src/__benchmark__/cog.read.benchmark.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 
-import { CogTiff } from '../cog.tiff.js';
+import { CogTiff } from '../tiff.js';
 import { TiffTag } from '../index.js';
 import { SourceMemory } from './source.memory.js';
 

--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'fs';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
 import { SourceMemory } from '../__benchmark__/source.memory.js';
-import { CogTiff } from '../tiff.js';
+import { Tiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { ByteSize } from '../util/bytes.js';
 
@@ -19,7 +19,7 @@ function getResolution(zoom: number): number {
 
 describe('CogTiled', () => {
   const cogSourceFile = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
-  const cog = new CogTiff(cogSourceFile);
+  const cog = new Tiff(cogSourceFile);
 
   beforeEach(() => cog.init());
 
@@ -87,7 +87,7 @@ describe('Cog.Big', () => {
   it('should support reading from memory', async () => {
     const fullSource = new TestFileSource(new URL('../../data/sparse.tiff', import.meta.url));
 
-    const cog = new CogTiff(fullSource);
+    const cog = new Tiff(fullSource);
     await cog.init();
 
     const [firstImage] = cog.images;
@@ -101,7 +101,7 @@ describe('Cog.Big', () => {
   it('should read using a memory source', async () => {
     const bytes = await fs.readFile(new URL('../../data/sparse.tiff', import.meta.url));
     const source = new SourceMemory(bytes.buffer);
-    const cog = new CogTiff(source);
+    const cog = new Tiff(source);
     await cog.init();
 
     const [firstImage] = cog.images;
@@ -115,7 +115,7 @@ describe('Cog.Big', () => {
 
 describe('Cog.Sparse', () => {
   const cogSourceFile = new TestFileSource(new URL('../../data/sparse.tiff', import.meta.url));
-  const cog = new CogTiff(cogSourceFile);
+  const cog = new Tiff(cogSourceFile);
 
   it('should read metadata', async () => {
     await cog.init();
@@ -164,7 +164,7 @@ describe('Cog.Sparse', () => {
 
 describe('CogStrip', () => {
   const cogSourceFile = new TestFileSource(new URL('../../data/rgba8_strip.tiff', import.meta.url));
-  const cog = new CogTiff(cogSourceFile);
+  const cog = new Tiff(cogSourceFile);
 
   beforeEach(() => cog.init());
 

--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -5,8 +5,8 @@ import { promises as fs } from 'fs';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
 import { SourceMemory } from '../__benchmark__/source.memory.js';
-import { Tiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
+import { Tiff } from '../tiff.js';
 import { ByteSize } from '../util/bytes.js';
 
 // 900913 properties.

--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -17,7 +17,7 @@ function getResolution(zoom: number): number {
   return InitialResolution / 2 ** zoom;
 }
 
-describe('CogTiled', () => {
+describe('TiffTiled', () => {
   const cogSourceFile = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
   const cog = new Tiff(cogSourceFile);
 

--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'fs';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
 import { SourceMemory } from '../__benchmark__/source.memory.js';
-import { CogTiff } from '../cog.tiff.js';
+import { CogTiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { ByteSize } from '../util/bytes.js';
 

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
-import { CogTiff } from '../cog.tiff.js';
+import { CogTiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { TiffVersion } from '../const/tiff.version.js';
 import { TiffTag, TiffTagGeo } from '../index.js';

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -2,12 +2,12 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
-import { CogTiff } from '../tiff.js';
+import { Tiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { TiffVersion } from '../const/tiff.version.js';
 import { TiffTag, TiffTagGeo } from '../index.js';
 
-function validate(tif: CogTiff): void {
+function validate(tif: Tiff): void {
   assert.equal(tif.images.length, 5);
 
   const [firstTif] = tif.images;
@@ -31,7 +31,7 @@ describe('CogRead', () => {
 
   it('should read big tiff', async () => {
     const source = new TestFileSource(new URL('../../data/big_cog.tiff', import.meta.url));
-    const tiff = new CogTiff(source);
+    const tiff = new Tiff(source);
 
     await tiff.init();
 
@@ -42,7 +42,7 @@ describe('CogRead', () => {
 
   it('should read tiff', async () => {
     const source = new TestFileSource(new URL('../../data/cog.tiff', import.meta.url));
-    const tiff = new CogTiff(source);
+    const tiff = new Tiff(source);
 
     await tiff.init();
 
@@ -56,7 +56,7 @@ describe('CogRead', () => {
 
   it('should allow multiple init', async () => {
     const source = new TestFileSource(new URL('../../data/cog.tiff', import.meta.url));
-    const tiff = new CogTiff(source);
+    const tiff = new Tiff(source);
 
     assert.equal(tiff.isInitialized, false);
     await tiff.init();
@@ -70,7 +70,7 @@ describe('CogRead', () => {
 
   it('should read ifds from anywhere in the file', async () => {
     const source = new TestFileSource(new URL('../../data/DEM_BS28_2016_1000_1141.tif', import.meta.url));
-    const tiff = await CogTiff.create(source);
+    const tiff = await Tiff.create(source);
 
     assert.equal(tiff.images.length, 1);
     const im = tiff.images[0];
@@ -88,7 +88,7 @@ describe('CogRead', () => {
     const source = new TestFileSource(
       new URL('../../data/east_coast_phase3_2023_AY31_1000_3335.tif.gz', import.meta.url),
     );
-    const tiff = await CogTiff.create(source);
+    const tiff = await Tiff.create(source);
 
     assert.equal(tiff.images.length, 5);
     const im = tiff.images[0];

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
-import { Tiff } from '../tiff.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { TiffVersion } from '../const/tiff.version.js';
 import { TiffTag, TiffTagGeo } from '../index.js';
+import { Tiff } from '../tiff.js';
 
 function validate(tif: Tiff): void {
   assert.equal(tif.images.length, 5);

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -20,7 +20,7 @@ describe('CogRead', () => {
   // TODO this does not load 100% yet
   // it('should read big endian', async () => {
   //     const source = new TestFileSource(new URL('../../data/big_cog.tiff', import.meta.url));
-  //     const tiff = new CogTiff(source);
+  //     const tiff = new Tiff(source);
 
   //     await tiff.init();
 

--- a/packages/core/src/__test__/example.ts
+++ b/packages/core/src/__test__/example.ts
@@ -1,10 +1,10 @@
 import { SourceHttp } from '@chunkd/source-http';
 
-import { CogTiff } from '../index.js';
+import { Tiff } from '../index.js';
 
 async function main(): Promise<void> {
   const source = new SourceHttp('https://example.com/cog.tif');
-  const tiff = await CogTiff.create(source);
+  const tiff = await Tiff.create(source);
 
   /** Load a specific tile from a specific image */
   const tile = await tiff.images[5].getTile(2, 2);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
-export { CogTiffImage } from './cog.tiff.image.js';
-export { CogTiff } from './cog.tiff.js';
+export { CogTiffImage } from './tiff.image.js';
+export { CogTiff } from './tiff.js';
 export { TiffEndian } from './const/tiff.endian.js';
 export { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 export { TiffTag, TiffTagGeo, TiffTagGeoValueLookup, TiffTagValueLookup } from './const/tiff.tag.id.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
-export { CogTiffImage } from './tiff.image.js';
-export { CogTiff } from './tiff.js';
+export { TiffImage } from './tiff.image.js';
+export { Tiff } from './tiff.js';
 export { TiffEndian } from './const/tiff.endian.js';
 export { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 export { TiffTag, TiffTagGeo, TiffTagGeoValueLookup, TiffTagValueLookup } from './const/tiff.tag.id.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,3 @@
-export { TiffImage } from './tiff.image.js';
-export { Tiff } from './tiff.js';
 export { TiffEndian } from './const/tiff.endian.js';
 export { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 export { TiffTag, TiffTagGeo, TiffTagGeoValueLookup, TiffTagValueLookup } from './const/tiff.tag.id.js';
@@ -8,5 +6,7 @@ export { TiffVersion } from './const/tiff.version.js';
 export { Tag, TagInline, TagLazy, TagOffset } from './read/tiff.tag.js';
 export { getTiffTagSize } from './read/tiff.value.reader.js';
 export { Source } from './source.js';
+export { TiffImage } from './tiff.image.js';
+export { Tiff } from './tiff.js';
 export { toHex } from './util/util.hex.js';
 export type { BoundingBox, Point, Size, Vector } from './vector.js';

--- a/packages/core/src/read/tiff.gdal.ts
+++ b/packages/core/src/read/tiff.gdal.ts
@@ -22,7 +22,7 @@ export enum GhostOptionTileLeader {
  * GDAL has made a ghost set of options for Tiff files
  * this class represents the optimizations that GDAL has applied
  */
-export class CogTifGhostOptions {
+export class TiffGhostOptions {
   options: Map<string, string> = new Map();
 
   /**

--- a/packages/core/src/read/tiff.tag.factory.ts
+++ b/packages/core/src/read/tiff.tag.factory.ts
@@ -1,4 +1,4 @@
-import { CogTiff } from '../cog.tiff.js';
+import { CogTiff } from '../tiff.js';
 import { TiffTag } from '../const/tiff.tag.id.js';
 import { TiffTagValueType } from '../const/tiff.tag.value.js';
 import { getUint, getUint64 } from '../util/bytes.js';

--- a/packages/core/src/read/tiff.tag.factory.ts
+++ b/packages/core/src/read/tiff.tag.factory.ts
@@ -77,7 +77,7 @@ function readValue<T>(tiff: Tiff, bytes: DataView, offset: number, type: TiffTag
 }
 
 /**
- * Determine if all the data for the tiff tag is loaded in and use that to create the specific CogTiffTag
+ * Determine if all the data for the tiff tag is loaded in and use that to create the specific TiffTag
  *
  * @see {@link Tag}
  *

--- a/packages/core/src/read/tiff.tag.factory.ts
+++ b/packages/core/src/read/tiff.tag.factory.ts
@@ -1,6 +1,6 @@
-import { Tiff } from '../tiff.js';
 import { TiffTag } from '../const/tiff.tag.id.js';
 import { TiffTagValueType } from '../const/tiff.tag.value.js';
+import { Tiff } from '../tiff.js';
 import { getUint, getUint64 } from '../util/bytes.js';
 import { DataViewOffset, hasBytes } from './data.view.offset.js';
 import { Tag, TagLazy, TagOffset } from './tiff.tag.js';

--- a/packages/core/src/read/tiff.tag.factory.ts
+++ b/packages/core/src/read/tiff.tag.factory.ts
@@ -1,4 +1,4 @@
-import { CogTiff } from '../tiff.js';
+import { Tiff } from '../tiff.js';
 import { TiffTag } from '../const/tiff.tag.id.js';
 import { TiffTagValueType } from '../const/tiff.tag.value.js';
 import { getUint, getUint64 } from '../util/bytes.js';
@@ -54,7 +54,7 @@ function readTagValue(
   }
 }
 
-function readValue<T>(tiff: CogTiff, bytes: DataView, offset: number, type: TiffTagValueType, count: number): T {
+function readValue<T>(tiff: Tiff, bytes: DataView, offset: number, type: TiffTagValueType, count: number): T {
   const typeSize = getTiffTagSize(type);
   const dataLength = count * typeSize;
 
@@ -85,7 +85,7 @@ function readValue<T>(tiff: CogTiff, bytes: DataView, offset: number, type: Tiff
  * @param view Bytes to read from
  * @param offset Offset in the dataview to read a tag
  */
-export function createTag(tiff: CogTiff, view: DataViewOffset, offset: number): Tag<unknown> {
+export function createTag(tiff: Tiff, view: DataViewOffset, offset: number): Tag<unknown> {
   const tagId = view.getUint16(offset + 0, tiff.isLittleEndian);
 
   const dataType = view.getUint16(offset + 2, tiff.isLittleEndian) as TiffTagValueType;
@@ -131,7 +131,7 @@ export function createTag(tiff: CogTiff, view: DataViewOffset, offset: number): 
 }
 
 /** Fetch the value from a {@link TagLazy} tag */
-export async function fetchLazy<T>(tag: TagLazy<T>, tiff: CogTiff): Promise<T> {
+export async function fetchLazy<T>(tag: TagLazy<T>, tiff: Tiff): Promise<T> {
   if (tag.value != null) return tag.value;
   const dataTypeSize = getTiffTagSize(tag.dataType);
   const dataLength = dataTypeSize * tag.count;
@@ -144,7 +144,7 @@ export async function fetchLazy<T>(tag: TagLazy<T>, tiff: CogTiff): Promise<T> {
 /**
  * Fetch all the values from a {@link TagOffset}
  */
-export async function fetchAllOffsets(tiff: CogTiff, tag: TagOffset): Promise<number[]> {
+export async function fetchAllOffsets(tiff: Tiff, tag: TagOffset): Promise<number[]> {
   const dataTypeSize = getTiffTagSize(tag.dataType);
 
   if (tag.view == null) {
@@ -166,7 +166,7 @@ export function setBytes(tag: TagOffset, view: DataViewOffset): void {
 }
 
 /** Partially fetch the values of a {@link TagOffset} and return the value for the offset */
-export async function getValueAt(tiff: CogTiff, tag: TagOffset, index: number): Promise<number> {
+export async function getValueAt(tiff: Tiff, tag: TagOffset, index: number): Promise<number> {
   if (index > tag.count || index < 0) throw new Error('TagOffset: out of bounds :' + index);
   if (tag.value[index] != null) return tag.value[index];
   const dataTypeSize = getTiffTagSize(tag.dataType);

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -1,8 +1,8 @@
-import { Tiff } from './tiff.js';
 import { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 import { SubFileType, TiffTag, TiffTagGeo, TiffTagGeoType, TiffTagType } from './const/tiff.tag.id.js';
 import { fetchAllOffsets, fetchLazy, getValueAt } from './read/tiff.tag.factory.js';
 import { Tag, TagInline, TagOffset } from './read/tiff.tag.js';
+import { Tiff } from './tiff.js';
 import { getUint } from './util/bytes.js';
 import { BoundingBox, Size } from './vector.js';
 

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -1,4 +1,4 @@
-import { CogTiff } from './cog.tiff.js';
+import { CogTiff } from './tiff.js';
 import { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 import { SubFileType, TiffTag, TiffTagGeo, TiffTagGeoType, TiffTagType } from './const/tiff.tag.id.js';
 import { fetchAllOffsets, fetchLazy, getValueAt } from './read/tiff.tag.factory.js';

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -1,4 +1,4 @@
-import { CogTiff } from './tiff.js';
+import { Tiff } from './tiff.js';
 import { TiffCompression, TiffMimeType } from './const/tiff.mime.js';
 import { SubFileType, TiffTag, TiffTagGeo, TiffTagGeoType, TiffTagType } from './const/tiff.tag.id.js';
 import { fetchAllOffsets, fetchLazy, getValueAt } from './read/tiff.tag.factory.js';
@@ -12,7 +12,7 @@ export const InvalidProjectionCode = 32767;
 /**
  * Number of tiles used inside this image
  */
-export interface CogTiffImageTiledCount {
+export interface TiffImageTileCount {
   /** Number of tiles on the x axis */
   x: number;
   /** Number of tiles on the y axis */
@@ -38,14 +38,14 @@ export const ImportantTags = new Set([
 /**
  * Size of a individual tile
  */
-export interface CogTiffImageTileSize {
+export interface TiffImageTileSize {
   /** Tile width (pixels) */
   width: number;
   /** Tile height (pixels) */
   height: number;
 }
 
-export class CogTiffImage {
+export class TiffImage {
   /**
    * Id of the tif image, generally the image index inside the tif
    * where 0 is the root image, and every sub image is +1
@@ -54,7 +54,7 @@ export class CogTiffImage {
    */
   id: number;
   /** Reference to the TIFF that owns this image */
-  tiff: CogTiff;
+  tiff: Tiff;
   /** Has loadGeoTiffTags been called */
   isGeoTagsLoaded = false;
   /** Sub tags stored in TiffTag.GeoKeyDirectory */
@@ -62,7 +62,7 @@ export class CogTiffImage {
   /** All IFD tags that have been read for the image */
   tags: Map<TiffTag, Tag>;
 
-  constructor(tiff: CogTiff, id: number, tags: Map<TiffTag, Tag>) {
+  constructor(tiff: Tiff, id: number, tags: Map<TiffTag, Tag>) {
     this.tiff = tiff;
     this.id = id;
     this.tags = tags;
@@ -98,8 +98,8 @@ export class CogTiffImage {
   /**
    * Get the value of a TiffTag if it has been loaded, null otherwise.
    *
-   * If the value is not loaded use {@link CogTiffImage.fetch} to load the value
-   * Or use {@link CogTiffImage.has} to check if the tag exists
+   * If the value is not loaded use {@link TiffImage.fetch} to load the value
+   * Or use {@link TiffImage.has} to check if the tag exists
    *
    *
    * @returns value if loaded, null otherwise
@@ -356,7 +356,7 @@ export class CogTiffImage {
   /**
    * Get size of individual tiles
    */
-  get tileSize(): CogTiffImageTileSize {
+  get tileSize(): TiffImageTileSize {
     const width = this.value(TiffTag.TileWidth);
     const height = this.value(TiffTag.TileHeight);
     if (width == null || height == null) throw new Error('Tiff is not tiled');
@@ -366,7 +366,7 @@ export class CogTiffImage {
   /**
    * Number of tiles used to create this image
    */
-  get tileCount(): CogTiffImageTiledCount {
+  get tileCount(): TiffImageTileCount {
     const size = this.size;
     const tileSize = this.tileSize;
     const x = Math.ceil(size.width / tileSize.width);
@@ -551,11 +551,7 @@ export class CogTiffImage {
   }
 }
 
-function getOffset(
-  tiff: CogTiff,
-  x: TagOffset | TagInline<number | number[]>,
-  index: number,
-): number | Promise<number> {
+function getOffset(tiff: Tiff, x: TagOffset | TagInline<number | number[]>, index: number): number | Promise<number> {
   if (index > x.count || index < 0) throw new Error('TagIndex: out of bounds ' + x.id + ' @ ' + index);
   if (x.type === 'inline') {
     if (x.count > 1) return (x.value as number[])[index] as number;

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -532,7 +532,7 @@ export class TiffImage {
     const leaderBytes = this.tiff.options?.tileLeaderByteSize;
     if (leaderBytes) {
       const offset = await getOffset(this.tiff, this.tileOffset, index);
-      // Sparse COG no data found
+      // Sparse tiff no data found
       if (offset === 0) return { offset: 0, imageSize: 0 };
 
       // This fetch will generally load in the bytes needed for the image too

--- a/packages/core/src/tiff.ts
+++ b/packages/core/src/tiff.ts
@@ -34,13 +34,13 @@ export class Tiff {
     this.source = source;
   }
 
-  /** Create a COG and initialize it by reading the COG headers */
+  /** Create a tiff and initialize it by reading the tiff headers */
   static create(source: Source): Promise<Tiff> {
     return new Tiff(source).init();
   }
 
   /**
-   * Initialize the COG loading in the header and all image headers
+   * Initialize the tiff loading in the header and all image headers
    */
   init(): Promise<Tiff> {
     if (this._initPromise) return this._initPromise;

--- a/packages/core/src/tiff.ts
+++ b/packages/core/src/tiff.ts
@@ -1,4 +1,4 @@
-import { CogTiffImage } from './cog.tiff.image.js';
+import { CogTiffImage } from './tiff.image.js';
 import { TiffEndian } from './const/tiff.endian.js';
 import { TiffTag } from './const/tiff.tag.id.js';
 import { TiffVersion } from './const/tiff.version.js';

--- a/packages/core/src/tiff.ts
+++ b/packages/core/src/tiff.ts
@@ -1,4 +1,3 @@
-import { TiffImage } from './tiff.image.js';
 import { TiffEndian } from './const/tiff.endian.js';
 import { TiffTag } from './const/tiff.tag.id.js';
 import { TiffVersion } from './const/tiff.version.js';
@@ -8,6 +7,7 @@ import { TiffGhostOptions } from './read/tiff.gdal.js';
 import { TagTiffBigConfig, TagTiffConfig, TiffIfdConfig } from './read/tiff.ifd.config.js';
 import { createTag } from './read/tiff.tag.factory.js';
 import { Source } from './source.js';
+import { TiffImage } from './tiff.image.js';
 import { getUint } from './util/bytes.js';
 import { toHex } from './util/util.hex.js';
 

--- a/packages/examples/src/browser/example.single.tile.ts
+++ b/packages/examples/src/browser/example.single.tile.ts
@@ -1,7 +1,7 @@
-import { CogTiff } from '@cogeotiff/core';
+import { Tiff } from '@cogeotiff/core';
 
 /** Loads a single tile from a COG and renders it as a <img /> element */
-export async function loadSingleTile(tiff: CogTiff): Promise<HTMLElement> {
+export async function loadSingleTile(tiff: Tiff): Promise<HTMLElement> {
   const startTime = performance.now();
   const img = tiff.images[tiff.images.length - 1];
   const tile = await img.getTile(0, 0);

--- a/packages/examples/src/browser/index.ts
+++ b/packages/examples/src/browser/index.ts
@@ -1,7 +1,7 @@
 import { SourceCache, SourceChunk } from '@chunkd/middleware';
 import { SourceCallback, SourceMiddleware, SourceRequest, SourceView } from '@chunkd/source';
 import { SourceHttp } from '@chunkd/source-http';
-import { CogTiff } from '@cogeotiff/core';
+import { Tiff } from '@cogeotiff/core';
 
 import { loadSingleTile } from './example.single.tile';
 
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     cache,
     fetchLog,
   ]);
-  const tiff = await CogTiff.create(tiffSource);
+  const tiff = await Tiff.create(tiffSource);
 
   const mainEl = document.createElement('div');
   console.log('Loaded: ', tiff.source.url, '\nImages:', tiff.images.length);


### PR DESCRIPTION
This library is used a log with tiffs that are not COGs so makes sense to update the types/docs to explain that.