### PR TITLE
feat: force some tags to always be arrays

### DIFF
--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -6,9 +6,9 @@ import { promises as fs } from 'fs';
 import { TestFileSource } from '../__benchmark__/source.file.js';
 import { SourceMemory } from '../__benchmark__/source.memory.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
+import { Photometric, TiffTag } from '../const/tiff.tag.id.js';
 import { Tiff } from '../tiff.js';
 import { ByteSize } from '../util/bytes.js';
-import { Photometric, TiffTag } from '../const/tiff.tag.id.js';
 
 // 900913 properties.
 const A = 6378137.0;

--- a/packages/core/src/__test__/cog.image.test.ts
+++ b/packages/core/src/__test__/cog.image.test.ts
@@ -8,6 +8,7 @@ import { SourceMemory } from '../__benchmark__/source.memory.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
 import { Tiff } from '../tiff.js';
 import { ByteSize } from '../util/bytes.js';
+import { Photometric, TiffTag } from '../const/tiff.tag.id.js';
 
 // 900913 properties.
 const A = 6378137.0;
@@ -132,6 +133,11 @@ describe('Cog.Sparse', () => {
 
     const { tileCount } = img;
     assert.deepEqual(tileCount, { x: 2, y: 2 });
+
+    assert.equal(img.value(TiffTag.SamplesPerPixel), 4); // 4 bands
+    assert.deepEqual(img.value(TiffTag.BitsPerSample), [8, 8, 8, 8]);
+    assert.equal(img.value(TiffTag.Photometric), Photometric.Rgb);
+    assert.equal(img.value(TiffTag.GdalNoData), null);
 
     for (let x = 0; x < tileCount.x; x++) {
       for (let y = 0; y < tileCount.y; y++) {

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -82,7 +82,7 @@ describe('CogRead', () => {
     assert.equal(im.isTiled(), false);
 
     // 32 bit float DEM
-    assert.deepEqual(im.value(TiffTag.BitsPerSample), 32);
+    assert.deepEqual(im.value(TiffTag.BitsPerSample), [32]);
     assert.equal(im.value(TiffTag.SampleFormat), SampleFormat.Float);
     assert.equal(im.value(TiffTag.Photometric), Photometric.MinIsBlack);
 

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -3,10 +3,10 @@ import { describe, it } from 'node:test';
 
 import { TestFileSource } from '../__benchmark__/source.file.js';
 import { TiffMimeType } from '../const/tiff.mime.js';
+import { Photometric, SampleFormat } from '../const/tiff.tag.id.js';
 import { TiffVersion } from '../const/tiff.version.js';
 import { TiffTag, TiffTagGeo } from '../index.js';
 import { Tiff } from '../tiff.js';
-import { Photometric, SampleFormat } from '../const/tiff.tag.id.js';
 
 function validate(tif: Tiff): void {
   assert.equal(tif.images.length, 5);

--- a/packages/core/src/__test__/cog.read.test.ts
+++ b/packages/core/src/__test__/cog.read.test.ts
@@ -6,6 +6,7 @@ import { TiffMimeType } from '../const/tiff.mime.js';
 import { TiffVersion } from '../const/tiff.version.js';
 import { TiffTag, TiffTagGeo } from '../index.js';
 import { Tiff } from '../tiff.js';
+import { Photometric, SampleFormat } from '../const/tiff.tag.id.js';
 
 function validate(tif: Tiff): void {
   assert.equal(tif.images.length, 5);
@@ -79,6 +80,12 @@ describe('CogRead', () => {
     assert.equal(im.epsg, 2193);
     assert.equal(im.compression, TiffMimeType.None);
     assert.equal(im.isTiled(), false);
+
+    // 32 bit float DEM
+    assert.deepEqual(im.value(TiffTag.BitsPerSample), 32);
+    assert.equal(im.value(TiffTag.SampleFormat), SampleFormat.Float);
+    assert.equal(im.value(TiffTag.Photometric), Photometric.MinIsBlack);
+
     assert.equal(im.tagsGeo.get(TiffTagGeo.GTCitationGeoKey), 'NZGD2000 / New Zealand Transverse Mercator 2000');
     assert.equal(im.tagsGeo.get(TiffTagGeo.GeodeticCitationGeoKey), 'NZGD2000');
     assert.deepEqual(await im.fetch(TiffTag.StripByteCounts), [8064, 8064, 8064, 8064, 8064, 8064, 8064, 5040]);
@@ -96,6 +103,7 @@ describe('CogRead', () => {
     assert.equal(im.isGeoTagsLoaded, true);
     assert.equal(im.epsg, 2193);
     assert.equal(im.compression, TiffMimeType.Lzw);
+    assert.deepEqual(im.value(TiffTag.BitsPerSample), [8, 8, 8, 8]);
 
     const geoTags = [...im.tagsGeo.keys()].map((key) => TiffTagGeo[key]);
     assert.deepEqual(geoTags, [

--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -369,8 +369,7 @@ export interface TiffTagType {
   [TiffTag.ImageHeight]: number;
   [TiffTag.ImageWidth]: number;
   [TiffTag.SubFileType]: SubFileType;
-  /** Number if only one band present */
-  [TiffTag.BitsPerSample]: number[] | number;
+  [TiffTag.BitsPerSample]: number[];
   [TiffTag.Compression]: Compression;
   [TiffTag.OldSubFileType]: OldSubFileType;
   [TiffTag.Photometric]: Photometric;

--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -379,16 +379,12 @@ export interface TiffTagType {
 
   [TiffTag.TileWidth]: number;
   [TiffTag.TileHeight]: number;
-  /** Will be number if only one tile is present  */
-  [TiffTag.TileOffsets]: number[] | number;
-  /** Will be number if only one tile is present  */
-  [TiffTag.TileByteCounts]: number[] | number;
+  [TiffTag.TileOffsets]: number[];
+  [TiffTag.TileByteCounts]: number[];
   [TiffTag.JpegTables]: number[];
 
-  /** Will be number if only one strip is present  */
-  [TiffTag.StripByteCounts]: number[] | number;
-  /** Will be number if only one strip is present  */
-  [TiffTag.StripOffsets]: number[] | number;
+  [TiffTag.StripByteCounts]: number[];
+  [TiffTag.StripOffsets]: number[];
 
   [TiffTag.SampleFormat]: SampleFormat;
   [TiffTag.GdalMetadata]: string;
@@ -396,8 +392,8 @@ export interface TiffTagType {
   [TiffTag.ModelPixelScale]: number[];
   [TiffTag.ModelTiePoint]: number[];
   [TiffTag.ModelTransformation]: number[];
-  [TiffTag.GeoKeyDirectory]: number[] | number;
-  [TiffTag.GeoDoubleParams]: number[] | number;
+  [TiffTag.GeoKeyDirectory]: number[];
+  [TiffTag.GeoDoubleParams]: number[];
   [TiffTag.GeoAsciiParams]: string;
 
   [TiffTag.PlanarConfiguration]: PlanarConfiguration;
@@ -767,4 +763,17 @@ export const TiffTagGeoValueLookup: Partial<Record<number, Record<number, string
   [TiffTagGeo.GeogAngularUnitsGeoKey]: GeoAngularUnits,
   [TiffTagGeo.ProjLinearUnitsGeoKey]: GeoLinearUnits,
   [TiffTagGeo.VerticalUnitsGeoKey]: GeoLinearUnits,
+};
+
+/**
+ * Convert tiff tag values when being read.
+ */
+export const TiffTagConvertArray: Partial<Record<TiffTag, boolean>> = {
+  [TiffTag.TileByteCounts]: true,
+  [TiffTag.TileOffsets]: true,
+  [TiffTag.StripOffsets]: true,
+  [TiffTag.StripByteCounts]: true,
+  [TiffTag.BitsPerSample]: true,
+  [TiffTag.GeoKeyDirectory]: true,
+  [TiffTag.GeoDoubleParams]: true,
 };

--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -156,12 +156,10 @@ export enum TiffTag {
   /**
    * Number of bits per channel
    *
-   * if only one band is present it is a number not a number[]
-   *
    * @example
    * ```typescript
    * [8,8,8] // 8 bit RGB
-   * 16 // 16bit
+   * [16] // 16bit
    * ```
    */
   BitsPerSample = 258,

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -381,7 +381,7 @@ export class TiffImage {
    *
    * @returns file offset to where the tiffs are stored
    */
-  get tileOffset(): TagOffset | TagInline<number | number[]> {
+  get tileOffset(): TagOffset | TagInline<number[]> {
     const tileOffset = this.tags.get(TiffTag.TileOffsets) as TagOffset;
     if (tileOffset == null) throw new Error('No tile offsets found');
     return tileOffset;
@@ -551,11 +551,8 @@ export class TiffImage {
   }
 }
 
-function getOffset(tiff: Tiff, x: TagOffset | TagInline<number | number[]>, index: number): number | Promise<number> {
+function getOffset(tiff: Tiff, x: TagOffset | TagInline<number[]>, index: number): number | Promise<number> {
   if (index > x.count || index < 0) throw new Error('TagIndex: out of bounds ' + x.id + ' @ ' + index);
-  if (x.type === 'inline') {
-    if (x.count > 1) return (x.value as number[])[index] as number;
-    return x.value as number;
-  }
+  if (x.type === 'inline') return x.value[index] as number;
   return getValueAt(tiff, x, index);
 }


### PR DESCRIPTION
Makes it so common array tags are always arrays even if they only have 1 value

```
TileByteCounts
TileOffsets
StripOffsets
StripByteCounts
BitsPerSample
GeoKeyDirectory
GeoDoubleParams
```