### PR TITLE
perf(core): load tile sizes from tag if it is already loaded

### DIFF
--- a/packages/cli/src/log.ts
+++ b/packages/cli/src/log.ts
@@ -1,12 +1,14 @@
 import { fsa, FsHttp } from '@chunkd/fs';
 import { SourceCache, SourceChunk } from '@chunkd/middleware';
+import { Tiff } from '@cogeotiff/core';
 import { log } from '@linzjs/tracing';
 
 import { FetchLog } from './fs.js';
 
 // Cache the last 10MB of chunks for reuse
 export const sourceCache = new SourceCache({ size: 10 * 1024 * 1024 });
-export const sourceChunk = new SourceChunk({ size: 32 * 1024 });
+export const sourceChunk = new SourceChunk({ size: 64 * 1024 });
+Tiff.DefaultReadSize = sourceChunk.chunkSize;
 
 export function setupLogger(cfg: { verbose?: boolean; extraVerbose?: boolean }): typeof log {
   if (cfg.verbose) {

--- a/packages/core/src/tiff.ts
+++ b/packages/core/src/tiff.ts
@@ -16,6 +16,12 @@ export class Tiff {
   static DefaultReadSize = 16 * 1024;
   /** Read 16KB blocks at a time */
   defaultReadSize = Tiff.DefaultReadSize;
+
+  /** Do not initialize tags that have greater than this many records see {@link createTag} */
+  static DefaultTagInitCount = 1024;
+  /** Do not initialize tags that are greater than this size see {@link createTag} */
+  defaultTagInitCount = Tiff.DefaultTagInitCount;
+
   /** Where this cog is fetching its data from */
   source: Source;
   /** Big or small Tiff */


### PR DESCRIPTION
#### Motivation 

to read a tile you need both the tile offset and size of the tile, a optimization that COGs do is to store the tile size just before the offset, so that if you read a chunk of data near the offset you generally get both the tile size and the content of the tile 

in some conditions this can result in multiple reads of the remote datasource, one to get the tile offset then one to get the tile content.

The tile size is also stored in the `TileByteCounts` tiff tag and if that is already loaded it should be the preffered method of fetching the tile size.

##### Modification

If the tile byte size tiff tag is loaded read the tile size from that tag instead.