### PR TITLE
refactor: Use defined `ImportantTags` global in `init`

### DIFF
--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -32,11 +32,7 @@ export const ImportantTags = new Set([
   TiffTag.TileWidth,
 ]);
 
-export const ImportantGeoTags = new Set([
-  TiffTag.GeoKeyDirectory,
-  TiffTag.GeoAsciiParams,
-  TiffTag.GeoDoubleParams,
-]);
+export const ImportantGeoTags = new Set([TiffTag.GeoKeyDirectory, TiffTag.GeoAsciiParams, TiffTag.GeoDoubleParams]);
 
 /**
  * Size of a individual tile
@@ -79,7 +75,7 @@ export class TiffImage {
   async init(loadGeoTags = true): Promise<void> {
     const requiredTags: Promise<unknown>[] = [];
     ImportantTags.forEach((tag) => {
-        requiredTags.push(this.fetch(tag));
+      requiredTags.push(this.fetch(tag));
     });
 
     if (loadGeoTags) {


### PR DESCRIPTION
It looked like maybe you had intended to use the `ImportantTags` global inside of `init`? It doesn't look to be used anywhere else in the repo