### PR TITLE
feat(cli): trace how a tiff is loaded with fetch-tile

### DIFF
--- a/packages/cli/src/commands/fetch-tile.ts
+++ b/packages/cli/src/commands/fetch-tile.ts
@@ -1,0 +1,95 @@
+import { fsa } from '@chunkd/fs';
+import { TagOffset, Tiff, TiffTag } from '@cogeotiff/core';
+import { command, number, option, optional, positional, string } from 'cmd-ts';
+
+import { DefaultArgs, Url } from '../common.js';
+import { FetchLog } from '../fs.js';
+import { setupLogger } from '../log.js';
+
+export const commandFetchTile = command({
+  name: 'fetch-tile',
+  args: {
+    ...DefaultArgs,
+    tile: option({
+      short: 't',
+      long: 'tile',
+      description: 'tile to process "z-x-y" multiple tiles can be fetched by comma separating them "z-x-y,z-x-y"',
+      type: string,
+      defaultValue: () => '0-0-0',
+    }),
+    output: option({ short: 'o', long: 'output', type: optional(Url) }),
+    readSize: option({
+      long: 'read-size',
+      description: 'Size of bytes to read for the tile, default is to read the whole tile in KB',
+      type: number,
+      defaultValue: () => 16,
+    }),
+    path: positional({ type: Url, description: 'File to process' }),
+  },
+
+  async handler(args) {
+    const logger = setupLogger(args);
+    if (logger.level === 'warn') logger.level = 'info';
+    fsa.middleware = [FetchLog]; // reset middleware so we don't cache or chunk requests
+
+    const tiles = args.tile.split(',').map((t) => t.split('-').map((s) => parseInt(s, 10)));
+    for (const t of tiles) {
+      if (isNaN(t[0]) || isNaN(t[1]) || isNaN(t[2])) {
+        logger.error('Invalid tile format, expected {z-x-y}', { tile: args.tile });
+        return;
+      }
+    }
+
+    const tiff = new Tiff(fsa.source(args.path));
+    tiff.defaultReadSize = args.readSize * 1024;
+
+    logger.debug('Tiff:load', { path: args.path.href });
+    const loadStart = performance.now();
+    await tiff.init();
+    const loadEnd = performance.now();
+    logger.info('Tiff:loaded', {
+      path: args.path.href,
+      fetches: FetchLog.fetches.length,
+      bytesRead: FetchLog.bytesRead,
+      duration: loadEnd - loadStart,
+    });
+
+    for (const i of tiff.images) {
+      const byteCount = i.tags.get(TiffTag.TileByteCounts) as TagOffset | undefined;
+      const tileOffsets = i.tags.get(TiffTag.TileOffsets) as TagOffset | undefined;
+      logger.debug('Image:TileInfo', {
+        image: i.id,
+        toLoaded: tileOffsets?.isLoaded,
+        bcLoaded: byteCount?.isLoaded,
+        bcOffset: byteCount?.dataOffset,
+        toOffset: tileOffsets?.dataOffset,
+        count: byteCount?.count,
+      });
+    }
+
+    for (const t of tiles) {
+      const [z, x, y] = t;
+
+      if (tiff.images.length < z || z < 0) {
+        logger.error('Invalid tile z level', { z, max: tiff.images.length });
+        return;
+      }
+
+      const image = tiff.images[z];
+      const tile = await image.getTile(x, y);
+      if (tile == null) {
+        logger.error('Failed to fetch tile', { z, x, y });
+        return;
+      }
+
+      logger.info('Tile:fetched', {
+        z,
+        x,
+        y,
+        bytes: tile.bytes.byteLength,
+        fetches: FetchLog.fetches.length,
+        bytesRead: FetchLog.bytesRead,
+      });
+    }
+  },
+});

--- a/packages/cli/src/fs.ts
+++ b/packages/cli/src/fs.ts
@@ -7,7 +7,7 @@ export const FetchLog: SourceMiddleware & { reset(): void; fetches: SourceReques
   fetch(req: SourceRequest, next: SourceCallback) {
     this.fetches.push(req);
     this.bytesRead += req.length ?? 0;
-    logger.info('Tiff:fetch', { href: req.source.url.href, offset: req.offset, length: req.length });
+    logger.debug('Tiff:fetch', { href: req.source.url.href, offset: req.offset, length: req.length });
     return next(req);
   },
   reset() {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { subcommands } from 'cmd-ts';
 
 import { commandDump } from './commands/dump.js';
+import { commandFetchTile } from './commands/fetch-tile.js';
 import { commandInfo } from './commands/info.js';
 
 export const cmd = subcommands({
@@ -9,5 +10,6 @@ export const cmd = subcommands({
   cmds: {
     info: commandInfo,
     dump: commandDump,
+    'fetch-tile': commandFetchTile,
   },
 });


### PR DESCRIPTION
### Motivation

I want to debug how a tiff is initalized quickly and easily, showing which parts of the tiff are loaded with varying levels of read window sizes

### Modifications

adds a `fetch-tile` CLI to read a individual tile (or collection of tiles) from a tiff then trace all the requests needed to read that tile.

### Verification

<img width="2833" height="449" alt="image" src="https://github.com/user-attachments/assets/46a4b70a-ced1-4937-ae44-2f166f649ee2" />
