### PR TITLE
build: use the .node-version to configure versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 24.x
+          node-version-file: '.node-version'
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,8 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 24.x
-
+          node-version-file: '.node-version'
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
### Motivation

Managing node versions across many repos is hard, `.node-version` lets us configure the required node version per repo, this has been set at the top level and github actions's setup-node supports the node-version file.


### Modifications

Swap build pipelines to use `.node-version`

### Verification

wait for build to run.
