### PR TITLE
feat: Improved type definitions for ModelPixelScale and ModelTransformation

### DIFF
--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -458,7 +458,7 @@ export interface TiffTagType {
   [TiffTag.GdalNoData]: string;
   // Always [ScaleX, ScaleY, ScaleZ]
   // https://web.archive.org/web/20240329145238/https://www.awaresystems.be/imaging/tiff/tifftags/modelpixelscaletag.html
-  [TiffTag.ModelPixelScale]: [number, number, number];
+  [TiffTag.ModelPixelScale]: [scaleX: number, scaleY: number, scaleZ: number];
   [TiffTag.ModelTiePoint]: number[];
   // Always 16 numbers
   // https://web.archive.org/web/20240329145255/https://www.awaresystems.be/imaging/tiff/tifftags/modeltransformationtag.html


### PR DESCRIPTION
Improved type definitions for easier downstream usage.

References: 

- https://web.archive.org/web/20240329145238/https://www.awaresystems.be/imaging/tiff/tifftags/modelpixelscaletag.html
- https://web.archive.org/web/20240329145255/https://www.awaresystems.be/imaging/tiff/tifftags/modeltransformationtag.html

It looks like ModelTiepoint tag isn't [strictly _required_](https://web.archive.org/web/20240329145303/https://www.awaresystems.be/imaging/tiff/tifftags/modeltiepointtag.html) to have only 6 elements