### PR TITLE
feat: New method to fetch multiple tiles concurrently, with range coalescing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4066,9 +4066,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,6 +32,21 @@ if (img.isTiled()) {
     tile.bytes; // Raw image buffer
 }
 
+/** Fetch many tiles in a single batched request — nearby byte ranges are coalesced
+ * into a small number of underlying reads. */
+const tiles = await img.getTiles([
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+]);
+// Results are returned in input order. Sparse tiles are `null`.
+for (const tile of tiles) {
+    if (tile == null) continue;
+    // tile.bytes, tile.mimeType, tile.compression
+}
+
 /** Get the origin point of the tiff */
 const origin = img.origin;
 /** Bounding box of the tiff */

--- a/packages/core/src/__test__/cog.image.tiles.test.ts
+++ b/packages/core/src/__test__/cog.image.tiles.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { TestFileSource } from '../__benchmark__/source.file.js';
+import { Tiff } from '../tiff.js';
+
+describe('TiffImage.getTiles', () => {
+  it('returns [] for empty input and makes no fetches', async () => {
+    const source = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const initialFetches = source.fetches.length;
+
+    const result = await tiff.images[0].getTiles([]);
+
+    assert.deepEqual(result, []);
+    assert.equal(source.fetches.length, initialFetches);
+  });
+
+  it('returns bytes equivalent to per-tile getTile for every tile', async () => {
+    const source = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const img = tiff.images[0];
+
+    const coords: { x: number; y: number }[] = [];
+    for (let y = 0; y < img.tileCount.y; y++) {
+      for (let x = 0; x < img.tileCount.x; x++) coords.push({ x, y });
+    }
+    assert.ok(coords.length > 1, `fixture must have >1 tile to exercise getTiles, got ${coords.length}`);
+
+    const expected = await Promise.all(coords.map((c) => img.getTile(c.x, c.y)));
+    const actual = await img.getTiles(coords);
+
+    assert.equal(actual.length, expected.length);
+    for (let i = 0; i < actual.length; i++) {
+      assert.equal(actual[i]?.mimeType, expected[i]?.mimeType);
+      assert.equal(actual[i]?.compression, expected[i]?.compression);
+      assert.deepEqual(new Uint8Array(actual[i]!.bytes), new Uint8Array(expected[i]!.bytes), `tile ${i} bytes differ`);
+    }
+  });
+
+  it('prepends JPEG header for JPEG-compressed tiles, matching getTile', async () => {
+    // cog.tiff is JPEG-compressed. image[0] has only one tile (1×1) but that is
+    // sufficient to verify the JPEG-header path runs through getTiles.
+    const source = new TestFileSource(new URL('../../data/cog.tiff', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const img = tiff.images[0];
+
+    const expected = await img.getTile(0, 0);
+    const [actual] = await img.getTiles([{ x: 0, y: 0 }]);
+
+    assert.ok(expected != null && actual != null);
+    assert.equal(actual.mimeType, expected.mimeType);
+    assert.equal(actual.compression, expected.compression);
+    assert.deepEqual(new Uint8Array(actual.bytes), new Uint8Array(expected.bytes));
+  });
+
+  it('throws on out-of-range tile coordinates', async () => {
+    const source = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const img = tiff.images[0];
+
+    await assert.rejects(() => img.getTiles([{ x: img.tileCount.x, y: 0 }]), /Tile index is outside of range/);
+    await assert.rejects(() => img.getTiles([{ x: 0, y: img.tileCount.y }]), /Tile index is outside of range/);
+  });
+
+  it('throws when called on an untiled image', async () => {
+    const source = new TestFileSource(new URL('../../data/model_transformation.tif', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const img = tiff.images[0];
+    assert.equal(img.isTiled(), false);
+
+    await assert.rejects(() => img.getTiles([{ x: 0, y: 0 }]), /Tiff is not tiled/);
+  });
+
+  it('returns null for sparse tiles', async () => {
+    const source = new TestFileSource(new URL('../../data/sparse.tiff', import.meta.url));
+    const tiff = await Tiff.create(source);
+    const img = tiff.images[4];
+    assert.deepEqual(img.tileCount, { x: 2, y: 2 });
+
+    const result = await img.getTiles([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ]);
+
+    assert.equal(result.length, 4);
+    for (const r of result) assert.equal(r, null);
+  });
+
+  it('uses source.fetchRanges when the source implements it', async () => {
+    const inner = new TestFileSource(new URL('../../data/rgba8_tiled.tiff', import.meta.url));
+
+    let fetchRangesCalls = 0;
+    let lastFetchRangesArgs: { offset: number; length: number }[] = [];
+    const wrapping = {
+      url: inner.url,
+      fetch: inner.fetch.bind(inner),
+      async fetchRanges(ranges: { offset: number; length: number }[]): Promise<ArrayBuffer[]> {
+        fetchRangesCalls++;
+        lastFetchRangesArgs = ranges;
+        return Promise.all(ranges.map((r) => inner.fetch(r.offset, r.length)));
+      },
+    };
+
+    const tiff = await Tiff.create(wrapping);
+    const img = tiff.images[0];
+
+    const fetchesBefore = inner.fetches.length;
+    const result = await img.getTiles([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+    ]);
+
+    assert.equal(fetchRangesCalls, 1);
+    assert.equal(lastFetchRangesArgs.length, 2);
+    assert.equal(result.length, 2);
+    assert.ok(inner.fetches.length - fetchesBefore >= 2);
+  });
+
+  it('coalesces adjacent tile data fetches when source has no fetchRanges', async () => {
+    const fixtureUrl = new URL('../../data/rgba8_tiled.tiff', import.meta.url);
+
+    // Baseline: per-tile getTile, count source.fetch calls in the data phase only.
+    const sourceA = new TestFileSource(fixtureUrl);
+    const tiffA = await Tiff.create(sourceA);
+    const imgA = tiffA.images[0];
+
+    const coords: { x: number; y: number }[] = [];
+    for (let y = 0; y < imgA.tileCount.y; y++) {
+      for (let x = 0; x < imgA.tileCount.x; x++) coords.push({ x, y });
+    }
+    assert.ok(coords.length > 1, 'fixture must have >1 tile');
+
+    const beforeIndividual = sourceA.fetches.length;
+    for (const c of coords) await imgA.getTile(c.x, c.y);
+    const individualFetchCount = sourceA.fetches.length - beforeIndividual;
+
+    // Batched: getTiles with a generous coalesce gap.
+    const sourceB = new TestFileSource(fixtureUrl);
+    const tiffB = await Tiff.create(sourceB);
+    const imgB = tiffB.images[0];
+
+    const beforeBatched = sourceB.fetches.length;
+    const batched = await imgB.getTiles(coords, { coalesce: 1024 * 1024 });
+    const batchedFetchCount = sourceB.fetches.length - beforeBatched;
+
+    assert.equal(batched.length, coords.length);
+    assert.ok(
+      batchedFetchCount < individualFetchCount,
+      `expected coalesced fetch count (${batchedFetchCount}) < individual (${individualFetchCount})`,
+    );
+  });
+});

--- a/packages/core/src/__test__/source.coalesce.test.ts
+++ b/packages/core/src/__test__/source.coalesce.test.ts
@@ -46,4 +46,14 @@ describe('coalesceRanges', () => {
     assert.deepEqual(result, []);
     assert.equal(source.fetches.length, 0);
   });
+
+  it('fetches a single range as one source call', async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, [{ offset: 10, length: 5 }]);
+
+    assert.equal(result.length, 1);
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([10, 11, 12, 13, 14]));
+    assert.equal(source.fetches.length, 1);
+    assert.deepEqual(source.fetches[0], { offset: 10, length: 5 });
+  });
 });

--- a/packages/core/src/__test__/source.coalesce.test.ts
+++ b/packages/core/src/__test__/source.coalesce.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { coalesceRanges } from '../source.coalesce.js';
+import type { Source } from '../source.js';
+
+/**
+ * Test source backed by an in-memory buffer. Records every fetch call so tests
+ * can assert call counts and arguments.
+ */
+class RecordingSource implements Source {
+  url = new URL('memory://recording');
+  fetches: { offset: number; length: number }[] = [];
+  /** Number of fetches in flight at any moment. Updated synchronously around the await. */
+  inflight = 0;
+  peakInflight = 0;
+  /** If set, every fetch awaits this many microtasks before returning, exposing concurrency. */
+  delayTicks = 0;
+
+  constructor(private readonly buffer: Uint8Array) {}
+
+  async fetch(offset: number, length: number): Promise<ArrayBuffer> {
+    this.fetches.push({ offset, length });
+    this.inflight++;
+    if (this.inflight > this.peakInflight) this.peakInflight = this.inflight;
+    try {
+      for (let i = 0; i < this.delayTicks; i++) await Promise.resolve();
+      const slice = this.buffer.slice(offset, offset + length);
+      return slice.buffer.slice(slice.byteOffset, slice.byteOffset + slice.byteLength) as ArrayBuffer;
+    } finally {
+      this.inflight--;
+    }
+  }
+}
+
+/** Build a buffer where each byte equals (index % 256). Easy to verify slices. */
+function makeBuffer(size: number): Uint8Array {
+  const buf = new Uint8Array(size);
+  for (let i = 0; i < size; i++) buf[i] = i & 0xff;
+  return buf;
+}
+
+describe('coalesceRanges', () => {
+  it('returns [] and makes no fetches for empty input', async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, []);
+    assert.deepEqual(result, []);
+    assert.equal(source.fetches.length, 0);
+  });
+});

--- a/packages/core/src/__test__/source.coalesce.test.ts
+++ b/packages/core/src/__test__/source.coalesce.test.ts
@@ -148,6 +148,58 @@ describe('coalesceRanges', () => {
     assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]));
   });
 
+  it('throws when source.fetch returns fewer bytes than requested', async () => {
+    class TruncatingSource implements Source {
+      url = new URL('memory://truncating');
+      async fetch(_offset: number, length: number): Promise<ArrayBuffer> {
+        const buf = new Uint8Array(length - 1);
+        return buf.buffer as ArrayBuffer;
+      }
+    }
+    const source = new TruncatingSource();
+
+    await assert.rejects(
+      () => coalesceRanges(source, [{ offset: 0, length: 10 }]),
+      /Failed to fetch bytes from offset:0 wanted:10 got:9/,
+    );
+  });
+
+  it('forwards AbortSignal to source.fetch', async () => {
+    const seenSignals: (AbortSignal | undefined)[] = [];
+    class SignalCapturingSource implements Source {
+      url = new URL('memory://signal');
+      async fetch(_offset: number, length: number, options?: { signal?: AbortSignal }): Promise<ArrayBuffer> {
+        seenSignals.push(options?.signal);
+        return new ArrayBuffer(length);
+      }
+    }
+    const source = new SignalCapturingSource();
+    const controller = new AbortController();
+
+    await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 4 },
+        { offset: 100, length: 4 },
+      ],
+      { coalesce: 8, signal: controller.signal },
+    );
+
+    assert.equal(seenSignals.length, 2);
+    for (const s of seenSignals) assert.equal(s, controller.signal);
+  });
+
+  it('caps in-flight source.fetch calls at 10', async () => {
+    const source = new RecordingSource(makeBuffer(10_000));
+    source.delayTicks = 5;
+
+    const ranges = Array.from({ length: 25 }, (_, i) => ({ offset: i * 200, length: 4 }));
+    await coalesceRanges(source, ranges, { coalesce: 8 });
+
+    assert.equal(source.fetches.length, 25);
+    assert.ok(source.peakInflight <= 10, `expected peakInflight <= 10, got ${source.peakInflight}`);
+  });
+
   it('returns results in input order even when input is out of offset order', async () => {
     const source = new RecordingSource(makeBuffer(256));
     const result = await coalesceRanges(

--- a/packages/core/src/__test__/source.coalesce.test.ts
+++ b/packages/core/src/__test__/source.coalesce.test.ts
@@ -56,4 +56,112 @@ describe('coalesceRanges', () => {
     assert.equal(source.fetches.length, 1);
     assert.deepEqual(source.fetches[0], { offset: 10, length: 5 });
   });
+
+  it('merges two adjacent ranges within coalesce gap into one fetch', async () => {
+    const source = new RecordingSource(makeBuffer(128));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 10, length: 4 }, // covers 10..14
+        { offset: 20, length: 4 }, // covers 20..24, gap = 6
+      ],
+      { coalesce: 16 },
+    );
+
+    assert.equal(source.fetches.length, 1);
+    assert.deepEqual(source.fetches[0], { offset: 10, length: 14 }); // 10..24
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([10, 11, 12, 13]));
+    assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([20, 21, 22, 23]));
+  });
+
+  it('does not merge ranges with gap larger than coalesce', async () => {
+    const source = new RecordingSource(makeBuffer(256));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 4 }, // covers 0..4
+        { offset: 100, length: 4 }, // covers 100..104, gap = 96
+      ],
+      { coalesce: 16 },
+    );
+
+    assert.equal(source.fetches.length, 2);
+    assert.deepEqual(source.fetches[0], { offset: 0, length: 4 });
+    assert.deepEqual(source.fetches[1], { offset: 100, length: 4 });
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([0, 1, 2, 3]));
+    assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([100, 101, 102, 103]));
+  });
+
+  it('refuses to merge when the result would exceed maxRangeSize', async () => {
+    const source = new RecordingSource(makeBuffer(1000));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 100 }, // covers 0..100
+        { offset: 110, length: 100 }, // covers 110..210, gap = 10, merged span = 210
+      ],
+      { coalesce: 32, maxRangeSize: 150 },
+    );
+
+    assert.equal(source.fetches.length, 2);
+    assert.deepEqual(source.fetches[0], { offset: 0, length: 100 });
+    assert.deepEqual(source.fetches[1], { offset: 110, length: 100 });
+    assert.equal(result[0].byteLength, 100);
+    assert.equal(result[1].byteLength, 100);
+  });
+
+  it('fetches a single oversized range in full (does not truncate input)', async () => {
+    const source = new RecordingSource(makeBuffer(500));
+    const result = await coalesceRanges(source, [{ offset: 0, length: 400 }], { maxRangeSize: 100 });
+
+    assert.equal(source.fetches.length, 1);
+    assert.deepEqual(source.fetches[0], { offset: 0, length: 400 });
+    assert.equal(result[0].byteLength, 400);
+  });
+
+  it('handles duplicate input ranges by reusing the same merged group', async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, [
+      { offset: 5, length: 3 },
+      { offset: 5, length: 3 },
+    ]);
+
+    assert.equal(source.fetches.length, 1);
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([5, 6, 7]));
+    assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([5, 6, 7]));
+  });
+
+  it('handles overlapping input ranges', async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 5, length: 10 }, // covers 5..15
+        { offset: 10, length: 10 }, // covers 10..20, overlaps + extends
+      ],
+      { coalesce: 16 },
+    );
+
+    assert.equal(source.fetches.length, 1);
+    assert.deepEqual(source.fetches[0], { offset: 5, length: 15 }); // 5..20
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]));
+    assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]));
+  });
+
+  it('returns results in input order even when input is out of offset order', async () => {
+    const source = new RecordingSource(makeBuffer(256));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 200, length: 4 },
+        { offset: 0, length: 4 },
+        { offset: 100, length: 4 },
+      ],
+      { coalesce: 8 },
+    );
+
+    assert.deepEqual(new Uint8Array(result[0]), new Uint8Array([200, 201, 202, 203]));
+    assert.deepEqual(new Uint8Array(result[1]), new Uint8Array([0, 1, 2, 3]));
+    assert.deepEqual(new Uint8Array(result[2]), new Uint8Array([100, 101, 102, 103]));
+  });
 });

--- a/packages/core/src/source.coalesce.ts
+++ b/packages/core/src/source.coalesce.ts
@@ -35,7 +35,77 @@ export async function coalesceRanges(
   options?: CoalesceOptions,
 ): Promise<ArrayBuffer[]> {
   if (ranges.length === 0) return [];
-  void source;
-  void options;
-  throw new Error('not implemented');
+
+  const coalesce = options?.coalesce ?? COALESCE_DEFAULT;
+  const maxRangeSize = options?.maxRangeSize ?? MAX_RANGE_SIZE_DEFAULT;
+  const signal = options?.signal;
+
+  const merged = mergeRanges(ranges, coalesce, maxRangeSize);
+
+  const fetched = await dispatchMerged(source, merged, signal);
+
+  const result = new Array<ArrayBuffer>(ranges.length);
+  for (let i = 0; i < ranges.length; i++) {
+    const range = ranges[i];
+    const groupIndex = findGroupIndex(merged, range.offset);
+    const group = merged[groupIndex];
+    const groupBytes = fetched[groupIndex];
+    const start = range.offset - group.offset;
+    const end = start + range.length;
+    if (end > groupBytes.byteLength) {
+      throw new Error(
+        `Failed to fetch bytes from offset:${range.offset} wanted:${range.length} got:${groupBytes.byteLength - start}`,
+      );
+    }
+    result[i] = groupBytes.slice(start, end);
+  }
+  return result;
+}
+
+/** Sort ranges by offset and merge consecutive ones whose gap <= coalesce and whose merged size <= maxRangeSize. */
+function mergeRanges(ranges: ByteRange[], coalesce: number, maxRangeSize: number): ByteRange[] {
+  const sorted = [...ranges].sort((a, b) => a.offset - b.offset);
+  const out: ByteRange[] = [];
+  let current: ByteRange | null = null;
+  for (const r of sorted) {
+    if (current == null) {
+      current = { offset: r.offset, length: r.length };
+      continue;
+    }
+    const currentEnd = current.offset + current.length;
+    const nextEnd = r.offset + r.length;
+    const gap = r.offset - currentEnd;
+    const mergedEnd = Math.max(currentEnd, nextEnd);
+    const mergedSize = mergedEnd - current.offset;
+    if (gap <= coalesce && mergedSize <= maxRangeSize) {
+      current.length = mergedEnd - current.offset;
+    } else {
+      out.push(current);
+      current = { offset: r.offset, length: r.length };
+    }
+  }
+  if (current != null) out.push(current);
+  return out;
+}
+
+/** Binary search for the merged group whose offset is the largest <= target. */
+function findGroupIndex(merged: ByteRange[], target: number): number {
+  let lo = 0;
+  let hi = merged.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (merged[mid].offset <= target) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+async function dispatchMerged(source: Source, merged: ByteRange[], signal?: AbortSignal): Promise<ArrayBuffer[]> {
+  const out = new Array<ArrayBuffer>(merged.length);
+  for (let i = 0; i < merged.length; i += COALESCE_PARALLEL) {
+    const batch = merged.slice(i, i + COALESCE_PARALLEL);
+    const results = await Promise.all(batch.map((g) => source.fetch(g.offset, g.length, { signal })));
+    for (let j = 0; j < results.length; j++) out[i + j] = results[j];
+  }
+  return out;
 }

--- a/packages/core/src/source.coalesce.ts
+++ b/packages/core/src/source.coalesce.ts
@@ -1,0 +1,41 @@
+import type { Source } from './source.js';
+
+/** Range requests with a gap less than or equal to this default will be coalesced. */
+export const COALESCE_DEFAULT = 1024 * 1024;
+
+/** No merged range will exceed this default size. */
+export const MAX_RANGE_SIZE_DEFAULT = 16 * 1024 * 1024;
+
+/** Up to this number of merged-range requests are dispatched in parallel. */
+export const COALESCE_PARALLEL = 10;
+
+export interface CoalesceOptions {
+  /** Max gap (bytes) between two ranges before they're merged. Default: 1 MiB. */
+  coalesce?: number;
+  /** Max size (bytes) of any merged range. Default: 16 MiB. */
+  maxRangeSize?: number;
+  /** Forwarded to source.fetch */
+  signal?: AbortSignal;
+}
+
+export interface ByteRange {
+  offset: number;
+  length: number;
+}
+
+/**
+ * Fetch the given byte ranges from a source, coalescing nearby ranges into a smaller number
+ * of underlying `source.fetch` calls. Returns one ArrayBuffer per input range, in input order.
+ *
+ * Internal helper — not exported from the package's public index.
+ */
+export async function coalesceRanges(
+  source: Source,
+  ranges: ByteRange[],
+  options?: CoalesceOptions,
+): Promise<ArrayBuffer[]> {
+  if (ranges.length === 0) return [];
+  void source;
+  void options;
+  throw new Error('not implemented');
+}

--- a/packages/core/src/source.ts
+++ b/packages/core/src/source.ts
@@ -15,6 +15,22 @@ export interface Source {
   /** Fetch bytes from a source */
   fetch(offset: number, length?: number, options?: { signal?: AbortSignal }): Promise<ArrayBuffer>;
 
+  /**
+   * Optional batched read.
+   *
+   * If provided, callers will prefer this over making multiple {@link Source.fetch} calls.
+   * Implementations are expected to coalesce nearby ranges internally to reduce the number
+   * of underlying requests. The returned array contains one ArrayBuffer per input range,
+   * in input order.
+   *
+   * If not provided, callers fall back to the internal coalescing helper, which dispatches
+   * via {@link Source.fetch}.
+   */
+  fetchRanges?(
+    ranges: { offset: number; length: number }[],
+    options?: { signal?: AbortSignal },
+  ): Promise<ArrayBuffer[]>;
+
   /** Optionally close the source, useful for sources that have open connections of file descriptors */
   close?(): Promise<void>;
 }

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -492,6 +492,20 @@ export class TiffImage {
     if (compression == null) compression = Compression.None; // No compression found default ??
     const mimeType = getCompressionMimeType(compression) ?? TiffMimeType.None;
 
+    return this.finalizeTileBytes(bytes, compression, mimeType);
+  }
+
+  /**
+   * Apply compression-specific post-processing to fetched tile bytes.
+   *
+   * Currently this only prepends the JPEG header for JPEG-compressed tiles. Shared between
+   * {@link getBytes} (single tile) and {@link getTiles} (batched).
+   */
+  private finalizeTileBytes(
+    bytes: ArrayBuffer,
+    compression: Compression,
+    mimeType: TiffMimeType,
+  ): { mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } {
     if (compression === Compression.Jpeg) return { mimeType, bytes: this.getJpegHeader(bytes), compression };
     return { mimeType, bytes, compression };
   }

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -3,6 +3,7 @@ import type { TiffTagGeoType, TiffTagType } from './const/tiff.tag.id.js';
 import { Compression, ModelTypeCode, SubFileType, TiffTag, TiffTagGeo } from './const/tiff.tag.id.js';
 import { fetchAllOffsets, fetchLazy, getValueAt, getValueAtSync } from './read/tiff.tag.factory.js';
 import type { Tag, TagInline, TagOffset } from './read/tiff.tag.js';
+import { coalesceRanges } from './source.coalesce.js';
 import type { Tiff, TiffFetchOptions } from './tiff.js';
 import { getUint } from './util/bytes.js';
 import type { BoundingBox, Size } from './vector.js';
@@ -543,6 +544,83 @@ export class TiffImage {
     const { offset, imageSize } = await this.getTileSize(idx, options);
 
     return this.getBytes(offset, imageSize, options);
+  }
+
+  /**
+   * Load multiple tiles in a single batched I/O round trip.
+   *
+   * Resolves the offsets/sizes for every requested tile, then dispatches the data fetches
+   * either via {@link Source.fetchRanges} (if the source implements it) or via the internal
+   * range-coalescing helper. Returns one entry per input tile, in input order. Sparse tiles
+   * yield `null` matching {@link getBytes}.
+   *
+   * @param tiles List of `{x, y}` tile coordinates within this image
+   * @param options Fetch options, plus optional coalescing knobs
+   */
+  async getTiles(
+    tiles: { x: number; y: number }[],
+    options?: TiffFetchOptions & { coalesce?: number; maxRangeSize?: number },
+  ): Promise<Array<{ mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } | null>> {
+    if (tiles.length === 0) return [];
+
+    const tileSize = this.tileSize;
+    if (tileSize == null) throw new Error('Tiff is not tiled');
+
+    const size = this.size;
+    const nyTiles = Math.ceil(size.height / tileSize.height);
+    const nxTiles = Math.ceil(size.width / tileSize.width);
+    const totalTiles = nxTiles * nyTiles;
+
+    const indices = new Array<number>(tiles.length);
+    for (let i = 0; i < tiles.length; i++) {
+      const { x, y } = tiles[i];
+      if (x >= nxTiles || y >= nyTiles) {
+        throw new Error(`Tile index is outside of range x:${x} >= ${nxTiles} or y:${y} >= ${nyTiles}`);
+      }
+      const idx = y * nxTiles + x;
+      if (idx >= totalTiles) throw new Error(`Tile index is outside of tile range: ${idx} >= ${totalTiles}`);
+      indices[i] = idx;
+    }
+
+    const sizes = await Promise.all(indices.map((i) => this.getTileSize(i, options)));
+
+    const results = new Array<{ mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } | null>(
+      tiles.length,
+    );
+    const realRanges: { offset: number; length: number }[] = [];
+    const realIndices: number[] = [];
+    for (let i = 0; i < sizes.length; i++) {
+      const s = sizes[i];
+      if (s.offset === 0 || s.imageSize === 0) {
+        results[i] = null;
+      } else {
+        realIndices.push(i);
+        realRanges.push({ offset: s.offset, length: s.imageSize });
+      }
+    }
+
+    if (realRanges.length > 0) {
+      const source = this.tiff.source;
+      const signal = options?.signal;
+      const fetched = source.fetchRanges
+        ? await source.fetchRanges(realRanges, { signal })
+        : await coalesceRanges(source, realRanges, {
+            coalesce: options?.coalesce,
+            maxRangeSize: options?.maxRangeSize,
+            signal,
+          });
+
+      let compression = this.value(TiffTag.Compression);
+      if (compression == null) compression = Compression.None;
+      const mimeType = getCompressionMimeType(compression) ?? TiffMimeType.None;
+
+      for (let k = 0; k < fetched.length; k++) {
+        const i = realIndices[k];
+        results[i] = this.finalizeTileBytes(fetched[k], compression, mimeType);
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/packages/core/src/tiff.image.ts
+++ b/packages/core/src/tiff.image.ts
@@ -497,6 +497,62 @@ export class TiffImage {
   }
 
   /**
+   * Read image bytes for multiple ranges in a single batched I/O round trip.
+   *
+   * Vectorized counterpart to {@link getBytes}. Dispatches via {@link Source.fetchRanges} when
+   * the source provides it, otherwise falls back to the internal range-coalescing helper.
+   * Returns one entry per input range, in input order. Sparse ranges (`offset === 0` or
+   * `byteCount === 0`) yield `null`, matching {@link getBytes}.
+   *
+   * @param ranges List of `{offset, byteCount}` byte ranges
+   * @param options Fetch options, plus optional coalescing knobs
+   */
+  async getMultipleBytes(
+    ranges: { offset: number; byteCount: number }[],
+    options?: TiffFetchOptions & { coalesce?: number; maxRangeSize?: number },
+  ): Promise<Array<{ mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } | null>> {
+    if (ranges.length === 0) return [];
+
+    const results = new Array<{ mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } | null>(
+      ranges.length,
+    );
+    const realRanges: { offset: number; length: number }[] = [];
+    const realIndices: number[] = [];
+    for (let i = 0; i < ranges.length; i++) {
+      const r = ranges[i];
+      if (r.offset === 0 || r.byteCount === 0) {
+        results[i] = null;
+      } else {
+        realIndices.push(i);
+        realRanges.push({ offset: r.offset, length: r.byteCount });
+      }
+    }
+
+    if (realRanges.length === 0) return results;
+
+    const source = this.tiff.source;
+    const signal = options?.signal;
+    const fetched = source.fetchRanges
+      ? await source.fetchRanges(realRanges, { signal })
+      : await coalesceRanges(source, realRanges, {
+          coalesce: options?.coalesce,
+          maxRangeSize: options?.maxRangeSize,
+          signal,
+        });
+
+    let compression = this.value(TiffTag.Compression);
+    if (compression == null) compression = Compression.None;
+    const mimeType = getCompressionMimeType(compression) ?? TiffMimeType.None;
+
+    for (let k = 0; k < fetched.length; k++) {
+      const i = realIndices[k];
+      results[i] = this.finalizeTileBytes(fetched[k], compression, mimeType);
+    }
+
+    return results;
+  }
+
+  /**
    * Apply compression-specific post-processing to fetched tile bytes.
    *
    * Currently this only prepends the JPEG header for JPEG-compressed tiles. Shared between
@@ -583,44 +639,10 @@ export class TiffImage {
     }
 
     const sizes = await Promise.all(indices.map((i) => this.getTileSize(i, options)));
-
-    const results = new Array<{ mimeType: TiffMimeType; bytes: ArrayBuffer; compression: Compression } | null>(
-      tiles.length,
+    return this.getMultipleBytes(
+      sizes.map((s) => ({ offset: s.offset, byteCount: s.imageSize })),
+      options,
     );
-    const realRanges: { offset: number; length: number }[] = [];
-    const realIndices: number[] = [];
-    for (let i = 0; i < sizes.length; i++) {
-      const s = sizes[i];
-      if (s.offset === 0 || s.imageSize === 0) {
-        results[i] = null;
-      } else {
-        realIndices.push(i);
-        realRanges.push({ offset: s.offset, length: s.imageSize });
-      }
-    }
-
-    if (realRanges.length > 0) {
-      const source = this.tiff.source;
-      const signal = options?.signal;
-      const fetched = source.fetchRanges
-        ? await source.fetchRanges(realRanges, { signal })
-        : await coalesceRanges(source, realRanges, {
-            coalesce: options?.coalesce,
-            maxRangeSize: options?.maxRangeSize,
-            signal,
-          });
-
-      let compression = this.value(TiffTag.Compression);
-      if (compression == null) compression = Compression.None;
-      const mimeType = getCompressionMimeType(compression) ?? TiffMimeType.None;
-
-      for (let k = 0; k < fetched.length; k++) {
-        const i = realIndices[k];
-        results[i] = this.finalizeTileBytes(fetched[k], compression, mimeType);
-      }
-    }
-
-    return results;
   }
 
   /**


### PR DESCRIPTION
As explained in #1432 I would like a method to fetch multiple tiles so that we can merge ranges for neighboring requests.

This is modeled after the Rust [`object-store`](https://docs.rs/object_store/latest/object_store/) crate and its [`get_ranges` method](https://docs.rs/object_store/latest/object_store/trait.ObjectStore.html#method.get_ranges)

I used Claude for generating the PR, but have gone through the PR myself and wrote up this summary by hand

### Modifications

- Add new `TiffImage.getTiles` method for fetching multiple tiles concurrently. This is the only new public API.
- Add optional `fetchRanges` method to `Source` interface
	- This is so that backends can customize how ranges are coalesced if needed. While in Rust I would provide a default implementation on the trait, here this is an optional interface method, and if the method isn't provided, then we choose a default implementation of coalescing nearby ranges.
	- Or, we could avoid putting this on the `Source` and just rely on the `coalesce` and `maxRangeSize` options passed to `getTiles`

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

- Added new tests for calling `getTiles` and for testing the range coalescing itself.