### PR TITLE
feat: Coerce ExtraSamples tag to always be array and add type hints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4066,9 +4066,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -454,7 +454,7 @@ export interface TiffTagType {
   [TiffTag.BitsPerSample]: number[];
   [TiffTag.ColorMap]: number[];
   [TiffTag.Compression]: Compression;
-  [TiffTag.ExtraSamples]: ExtraSample | ExtraSample[];
+  [TiffTag.ExtraSamples]: ExtraSample[];
   [TiffTag.ImageHeight]: number;
   [TiffTag.ImageWidth]: number;
   [TiffTag.OldSubFileType]: OldSubFileType;
@@ -852,9 +852,12 @@ export enum LinearUnit {
 }
 
 /**
- * Convert tiff tag values when being read.
+ * Convert tiff tag values to arrays when being read.
+ *
+ * This makes it easier to not check for number | number[]
  */
 export const TiffTagConvertArray: Partial<Record<TiffTag, boolean>> = {
+  [TiffTag.ExtraSamples]: true,
   [TiffTag.TileByteCounts]: true,
   [TiffTag.TileOffsets]: true,
   [TiffTag.StripOffsets]: true,

--- a/packages/core/src/const/tiff.tag.id.ts
+++ b/packages/core/src/const/tiff.tag.id.ts
@@ -99,6 +99,22 @@ export enum Compression {
   JpegXlDng17 = 52546,
 }
 
+/**
+ * Description of extra components.
+ *
+ * Specifies that each pixel has N extra components whose interpretation is
+ * defined by one of the values listed below. When this field is used, the
+ * SamplesPerPixel field has a value greater than the PhotometricInterpretation
+ * field suggests.
+ *
+ * @see https://web.archive.org/web/20240329145321/https://www.awaresystems.be/imaging/tiff/tifftags/extrasamples.html
+ */
+export enum ExtraSample {
+  Unspecified = 0,
+  AssociatedAlpha = 1,
+  UnassociatedAlpha = 2,
+}
+
 export enum PlanarConfiguration {
   /** single image plane */
   Contig = 1,
@@ -435,13 +451,15 @@ export enum TiffTag {
 
 /** Define the expected types for all the tiff tags */
 export interface TiffTagType {
+  [TiffTag.BitsPerSample]: number[];
+  [TiffTag.ColorMap]: number[];
+  [TiffTag.Compression]: Compression;
+  [TiffTag.ExtraSamples]: ExtraSample | ExtraSample[];
   [TiffTag.ImageHeight]: number;
   [TiffTag.ImageWidth]: number;
-  [TiffTag.SubFileType]: SubFileType;
-  [TiffTag.BitsPerSample]: number[];
-  [TiffTag.Compression]: Compression;
   [TiffTag.OldSubFileType]: OldSubFileType;
   [TiffTag.Photometric]: Photometric;
+  [TiffTag.SubFileType]: SubFileType;
 
   [TiffTag.TileWidth]: number;
   [TiffTag.TileHeight]: number;
@@ -494,10 +512,8 @@ export interface TiffTagType {
 
   [TiffTag.CellLength]: unknown;
   [TiffTag.CellWidth]: unknown;
-  [TiffTag.ColorMap]: unknown;
   [TiffTag.Copyright]: unknown;
   [TiffTag.DateTime]: unknown;
-  [TiffTag.ExtraSamples]: unknown;
   [TiffTag.FillOrder]: unknown;
   [TiffTag.FreeByteCounts]: unknown;
   [TiffTag.FreeOffsets]: unknown;


### PR DESCRIPTION
### Motivation

These tiff tags are untyped. It would be nice to have full typing of TIFF tags where possible.

### Modifications

- Added type hint for `TiffTag.Colormap: number[]`
- Added `TiffTag.ExtraSamples` to `TiffTagConvertArray` so that `ExtraSamples` is always converted to an array. (Otherwise it'll be exposed as `ExtraSamples | ExtraSamples[]`)
- Added type hint for `TiffTag.ExtraSamples: ExtraSamples[]`
- Added ExtraSamples enum.
- I had to update package-lock.json for CI to pass

### Verification

Verified against TIFF spec